### PR TITLE
Remove 2s sleep timer from /lib/bitcio

### DIFF
--- a/desk/lib/btcio.hoon
+++ b/desk/lib/btcio.hoon
@@ -228,7 +228,6 @@
   ^-  form:m
   ;<  res=(unit @ux)  bind:m
     (get-block-hash req-to ?~(id ~ `(cat 3 'get-block-hash-' u.id)) height)
-  ;<  *  bind:m  (sleep:strandio ~s2)
   ?~  res  (pure:m ~)
   (get-block-by-hash req-to id u.res)
 ::


### PR DESCRIPTION
Speeds up the time for %ord-watcher to index 1,230 blocks from ~40 minutes to ~1 minute.

Closes #19.