### PR TITLE
%urb-watcher: fix pretty-printer crash and naively retry on thread fail

### DIFF
--- a/desk/app/urb-watcher.hoon
+++ b/desk/app/urb-watcher.hoon
@@ -148,7 +148,11 @@
     ?+    sign-arvo  (on-arvo:def wire sign-arvo)
         [%khan %arow *]
       ?.  -.p.sign-arvo
-        ((slog leaf+<p.p.sign-arvo> ~) `this)
+        ?>  ?=([%khan %arow %.n *] sign-arvo)
+        %-  (slog leaf+"%urb-watcher: thread failed, retrying" +.p.p.sign-arvo)
+        :_  this
+        :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
+        ==
       ?>  ?=([%khan %arow %.y %noun *] sign-arvo)
       =/  [%khan %arow %.y %noun =vase]  sign-arvo
       =/  fx-and-state


### PR DESCRIPTION
This PR fixes the pretty printer crash in the case where the block processing thread fails, and it also naively re-runs the thread in that case. This may fix a certain class of RPC failures, and will at least give us more error output to better diagnose any deeper bugs.