### PR TITLE
onboarding: add --dunsafe flag to vere boot

### DIFF
--- a/onboarding/booting/gw-onboard.py
+++ b/onboarding/booting/gw-onboard.py
@@ -1365,7 +1365,7 @@ def boot_comet(
         webbrowser.open(f"{url}/spv-wallet")
 
     # Replace this process with vere
-    cmd = [vere_bin, "-w", pier_name, "-B", pill, "-G", feed, "--http-port", str(port)]
+    cmd = [vere_bin, "-w", pier_name, "-B", pill, "-G", feed, "--http-port", str(port), "--Dunsafe-dawn=true"]
     os.execvp(vere_bin, cmd)
 
 


### PR DESCRIPTION
Merge this once the flag is supported (and for now, required) by the version of Vere that gets included in the release.