### PR TITLE
Add 5s delay on snapshot request

### DIFF
--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -61,18 +61,7 @@
             %connect  `/apps/urb-watcher  dap.bowl
         ==  
     ==
-  ~&  "%urb-watcher: requesting a snapshot from the default sponsor."
-  :~  :*  %pass  /snapshot  %arvo  %i
-          %request
-          ^-  request:http
-          :*  %'GET'
-              'http://143.198.70.9:8081/apps/urb-watcher/snapshot'
-              :~  ['accept' 'application/x-urb-jam']
-              ==
-              ~
-          ==
-          *outbound-config:iris
-      ==
+  :~  [%pass /init/snapshot %arvo %b %wait (add ~s10 now.bowl)]
   ==
 ::
 ++  on-save
@@ -173,6 +162,29 @@
   |=  [=wire =sign-arvo]
   ^-  (quip card _this)
   ?+    wire  (on-arvo:def wire sign-arvo)
+  ::
+  ::  Send the iris snapshot request now that
+  ::  the agent is fully initialized.
+      [%init %snapshot ~]
+    ?.  ?=([%behn %wake *] sign-arvo)  (on-arvo:def wire sign-arvo)
+    ?^  error.sign-arvo
+      %-  (slog leaf+"%urb-watcher: /init/snapshot timer error" ~)
+      `this
+    ~&  "%urb-watcher: requesting a snapshot from the default sponsor."
+    :_  this
+    :~  :*  %pass  /snapshot
+            %arvo  %i
+            %request
+            ^-  request:http
+            :*  %'GET'
+                'http://143.198.70.9:8081/apps/urb-watcher/snapshot'
+                :~  ['accept' 'application/x-urb-jam']
+                ==
+                ~
+            ==
+            *outbound-config:iris
+        ==
+    ==
   ::
   ::  Run +get-blocks at regular intervals.
       [%timer ~]


### PR DESCRIPTION
Should prevent a crash where the request is sent and response received before the ship is fully initiated, mirroring the behaviour of %azimuth.