### PR TITLE
%urb-watcher: revert initialization changes

### DIFF
--- a/.github/workflows/deploy-desk.yml
+++ b/.github/workflows/deploy-desk.yml
@@ -8,7 +8,7 @@ env:
   DESK: groundwire
   SHIP_HOST: root@143.198.70.9
   PIER_PATH: /root/.local/share/groundwire-alpha/ribsyp-lidwex-mitdev-sopsyn--difrel-mapler-mitnyt-daplyd
-  TMUX_TAB: desk-distributor
+  TMUX_TAB: ribsyp
 
 jobs:
   deploy:
@@ -17,9 +17,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install peru
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y pipx
+          pipx ensurepath
+          pipx install peru
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Build desk
         run: |
-          make build
+          chmod +x build.sh
+          bash build.sh
 
       - name: Setup SSH
         run: |
@@ -30,10 +39,9 @@ jobs:
 
       - name: Deploy desk
         run: |
-          scp -r dist-spv/* ${SHIP_HOST}:${PIER_PATH}/spv-wallet/
-          scp -r dist-groundwire/* ${SHIP_HOST}:${PIER_PATH}/groundwire/
+          rsync -az --delete --exclude='.git*' \
+            dist/ ${SHIP_HOST}:${PIER_PATH}/${DESK}/
 
       - name: Commit desk on ship
         run: |
-          ssh ${SHIP_HOST} "tmux send-keys -t ${TMUX_TAB} '|commit %groundwire' Enter"
-          ssh ${SHIP_HOST} "tmux send-keys -t ${TMUX_TAB} '|commit %spv-wallet' Enter"
+          ssh ${SHIP_HOST} "tmux send-keys -t ${TMUX_TAB} '|commit %${DESK}' Enter"

--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -61,7 +61,18 @@
             %connect  `/apps/urb-watcher  dap.bowl
         ==  
     ==
-  :~  [%pass /init/snapshot %arvo %b %wait (add ~s10 now.bowl)]
+  ~&  "%urb-watcher: requesting a snapshot from the default sponsor."
+  :~  :*  %pass  /snapshot  %arvo  %i
+          %request
+          ^-  request:http
+          :*  %'GET'
+              'http://143.198.70.9:8081/apps/urb-watcher/snapshot'
+              :~  ['accept' 'application/x-urb-jam']
+              ==
+              ~
+          ==
+          *outbound-config:iris
+      ==
   ==
 ::
 ++  on-save
@@ -163,29 +174,6 @@
   ^-  (quip card _this)
   ?+    wire  (on-arvo:def wire sign-arvo)
   ::
-  ::  Send the iris snapshot request now that
-  ::  the agent is fully initialized.
-      [%init %snapshot ~]
-    ?.  ?=([%behn %wake *] sign-arvo)  (on-arvo:def wire sign-arvo)
-    ?^  error.sign-arvo
-      %-  (slog leaf+"%urb-watcher: /init/snapshot timer error" ~)
-      `this
-    ~&  "%urb-watcher: requesting a snapshot from the default sponsor."
-    :_  this
-    :~  :*  %pass  /snapshot
-            %arvo  %i
-            %request
-            ^-  request:http
-            :*  %'GET'
-                'http://143.198.70.9:8081/apps/urb-watcher/snapshot'
-                :~  ['accept' 'application/x-urb-jam']
-                ==
-                ~
-            ==
-            *outbound-config:iris
-        ==
-    ==
-  ::
   ::  Run +get-blocks at regular intervals.
       [%timer ~]
     :_  this
@@ -215,7 +203,7 @@
         ~&  >  '%urb-watcher received a snapshot! Now beginning indexing from its latest block.'
         :_  this(urb-state new-urb)
         :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
-            (listen-to-urb ~ [%| dap.bowl])
+            (listen-to-urb ~(key by unv-ids:new-urb) [%| dap.bowl])
         ==
       ==
     ==


### PR DESCRIPTION
This PR reverts the changes to the %urb-watcher initialization process from last week. 

I tested this by booting a ship using gw-onboard.py on my local setup in conjunction with the same Vere, pill, and comet-miner I've always used. The pill I use doesn't come pre-installed with the %groundwire desk, so I make and mount the groundwire desk, copy the files in, and install it manually. Upon doing so, I get the following output:

```
gall: installing %reg-tester
%reg-tester: on-init
gall: installing %urb-watcher
%urb-watcher: on-init
"%urb-watcher: requesting a snapshot from the default sponsor."
> |install our %groundwire
>=
gall: booted %reg-tester
gall: booted %urb-watcher
%urb-watcher: on-arvo on wire /snapshot, [%iris %http-response]
>   '%urb-watcher received a snapshot! Now beginning indexing from its latest block.'
%urb-watcher: on-watch on path /~rovlur-namryp-barsup-dacdyt--randux-passeg-hopbel-daplyd
%urb-watcher: on-watch on path /~racnec-nomsut-rovwyx-bilmud--locdyr-samhet-ridbud-daplyd
%urb-watcher: on-watch on path /~sonhep-bisdet-tilnec-fogput--dolbur-livdun-matmet-daplyd
%urb-watcher: on-watch on path /~padwep-patruc-nisluc-fiddeb--rithec-dismyl-locweb-daplyd
%urb-watcher: on-watch on path /~noplyx-walhul-rinter-taprym--mocnup-matzod-somwex-daplyd
%urb-watcher: on-watch on path /~bosper-davrus-mocsef-digdeb--ravpyl-napner-sorwed-daplyd
%urb-watcher: on-watch on path /~nodpem-mapwyl-rocbec-forleb--somdes-sarwel-fabten-daplyd
%urb-watcher: on-watch on path /~minryl-racryt-miswyx-miptul--nactec-raptyr-hosref-daplyd
%urb-watcher: on-watch on path /~wolrut-torbur-nattyp-dozsut--riplug-ronreg-libnyx-daplyd
%urb-watcher: on-watch on path /~pitdus-tarryx-fadsup-sablep--linwyt-salbyn-batpun-daplyd
%urb-watcher: on-watch on path /~tagbyn-topsef-ragluc-harnex--tasryd-bosdul-watfep-daplyd
%urb-watcher: on-watch on path /~natser-timmel-fidpet-hidtex--tollen-lodnys-mogfex-daplyd
%urb-watcher: on-watch on path /~sigpeg-winwen-ropweg-midren--lidtug-patfun-sibfyr-daplyd
%urb-watcher: on-watch on path /~sorrud-witpet-foghex-tonten--tasnus-nispes-lagnex-daplyd
%urb-watcher: on-watch on path /~timtyp-patnyr-sogler-bacbyn--sarryt-dirsev-rabdys-daplyd
%urb-watcher: on-watch on path /~lapdyr-hosner-silhul-danlyr--fignet-ripfen-rinren-daplyd
%urb-watcher: on-watch on path /~dozfyn-banpen-firdev-maspec--talluc-winmer-ridput-daplyd
%urb-watcher: on-watch on path /~natnux-natdur-hanter-fasrul--donmep-nomtyl-sablun-daplyd
%urb-watcher: on-watch on path /~bolwyd-hidmut-timfex-fammed--noclun-woldyt-sibsem-daplyd
%urb-watcher: on-watch on path /~witrud-picmeb-mippec-fonwen--bicrem-modwet-mogheb-daplyd
%urb-watcher: on-watch on path /~bidryp-linrev-rosbex-novpur--modtyn-mirwyt-fosnum-daplyd
%urb-watcher: on-watch on path /~sibbet-lagber-hocwes-pilbec--hastun-dibpem-nodreg-daplyd
%urb-watcher: on-watch on path /~ridmeg-fambyl-lannep-lismes--lidtev-ramnum-filput-daplyd
%urb-watcher: on-watch on path /~hopweb-nossep-macsum-dasted--noslug-tolnum-nomlec-daplyd
%urb-watcher: on-watch on path /~rigner-mirfes-saltuc-lidlex--fosmyn-todmeg-forrup-daplyd
%urb-watcher: on-watch on path /~palset-paldev-wallev-tonrum--tocdeg-natnyx-panryp-daplyd
%urb-watcher: on-watch on path /~sopnex-mitnel-rildyt-fogreg--daldev-ragder-partud-daplyd
%urb-watcher: on-watch on path /~mitrum-nalnus-docteg-nidbex--fidzod-batsel-sittel-daplyd
%urb-watcher: on-watch on path /~silnex-masrex-naclev-pacden--ricwer-mipdeg-dactug-daplyd
%urb-watcher: on-watch on path /~lopdeg-sapben-rilmyr-hacwep--wicryc-tirter-hoctyr-daplyd
%urb-watcher: on-watch on path /~hacpem-niswyx-livryg-fodsun--lidlyr-martyr-ronfed-daplyd
%urb-watcher: on-watch on path /~dilfyr-misryt-wathex-rapfus--socrem-barsup-samryc-daplyd
%urb-watcher: on-watch on path /~dirdur-rocfet-wictul-nolsyl--fopnyt-bonfus-fortuc-daplyd
%urb-watcher: on-watch on path /~mitlet-wacset-ralhex-pocled--todlus-fitmun-silruc-daplyd
%urb-watcher: on-watch on path /~tapweb-silryg-noplen-minseb--savdec-tinseb-bisnub-daplyd
%urb-watcher: on-watch on path /~radnex-tagpel-lomnys-batrex--havsyn-namhes-milnes-daplyd
%urb-watcher: on-watch on path /~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd
%urb-watcher: on-watch on path /~lannec-lapnec-tombyn-dassem--hattud-formyr-talmyr-daplyd
%urb-watcher: on-watch on path /~soglur-sidsed-siddus-ronpel--battyc-radfel-fashes-daplyd
%urb-watcher: on-watch on path /~patnyx-navpeg-dotlux-tomnum--tonnec-fiptul-donrep-daplyd
%urb-watcher: on-watch on path /~pasped-dozter-lasfyn-motdur--falseg-togmun-sovlyn-daplyd
%urb-watcher: on-watch on path /~sivrup-napleb-mirmur-balmud--hilpen-borrym-navsec-daplyd
ames: lamp ~rovlur-namryp-barsup-dacdyt--randux-passeg-hopbel-daplyd static ip .1.2.3.4 port 12345
ames: lamp ~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd static ip .143.198.70.9 port 59344
ames: lamp ~patnyx-navpeg-dotlux-tomnum--tonnec-fiptul-donrep-daplyd static ip .1.2.3.4 port 12345
```

Notice that these three lamps at the end correspond to comets with fiefs. I can scry Jael for data corresponding to any of the other found comets, e.g.:

```
.^((unit point:jael) %j /=pynt=/~sivrup-napleb-mirmur-balmud--hilpen-borrym-navsec-daplyd)
[ ~
  [ rift=0
    life=1
      keys
    [   n
      [ p=1
          q
        [ crypto-suite=2
            pass
          174.470.297.796.729.812.110.376.021.501.776.316.522.344.993.111.608.272.416.252.967.932.357.444.706.930.851.029.211.727.701.047.298.959.289.343.153.703.291.381.746.296.485.513.783.959.698.422.862.615.750.615.773.599.039.231.921.412.159.047.802.045.068.703.679.142.903.362.321.827.597.514.255.906.872.994.713.803.276.129.562.947.262.987.499.552.709.880.109.771.910.611.470.160.739
        ]
      ]
      l=~
      r=~
    ]
    sponsor=[~ ~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd]
    fief=~
  ]
]
```

When I attempt Ames:

```
.^(ship-state:ames %ax /=//=/peers/~sivrup-napleb-mirmur-balmud--hilpen-borrym-navsec-daplyd)
bail: 4
bail: 2
dojo: failed to process input
```

This *doesn't* crash the ship.

It beats me why this scry doesn't work here, but I find it unlikely that it has anything to do with how the interface between %urb-watcher and Jael changed when we introduced the snapshot changes. Even if it does end up being the case that the same data ending up in Jael in a slightly different way breaks Ames, that's a core issue that our userspace code's semantics shouldn't be worrying about.