### PR TITLE
%urb-watcher: revert to %listening to all ships

### DIFF
--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -61,6 +61,8 @@
             %connect  `/apps/urb-watcher  dap.bowl
         ==  
     ==
+  ::  The snapshot HTTP request fails from ++on-init when we include the %groundwire
+  ::  desk in a pill. We send it a few seconds later to get around this. %azimuth does this too.
   :~  [%pass /init/snapshot %arvo %b %wait (add ~s10 now.bowl)]
   ==
 ::

--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -215,7 +215,7 @@
         ~&  >  '%urb-watcher received a snapshot! Now beginning indexing from its latest block.'
         :_  this(urb-state new-urb)
         :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
-            (listen-to-urb ~ [%| dap.bowl])
+            (listen-to-urb ~(key by unv-ids:new-urb) [%| dap.bowl])
         ==
       ==
     ==


### PR DESCRIPTION
Replaces #88, since we actually do need to preserve the init snapshot timer.

As in #88:

```
gall: installing %reg-tester
%reg-tester: on-init
gall: installing %urb-watcher
%urb-watcher: on-init
> |install our %groundwire
>=
gall: booted %reg-tester
gall: booted %urb-watcher
%urb-watcher: on-arvo on wire /init/snapshot, [%behn %wake]
"%urb-watcher: requesting a snapshot from the default sponsor."
%urb-watcher: on-arvo on wire /snapshot, [%iris %http-response]
>   '%urb-watcher received a snapshot! Now beginning indexing from its latest block.'
%urb-watcher: on-watch on path /~rovlur-namryp-barsup-dacdyt--randux-passeg-hopbel-daplyd
%urb-watcher: on-watch on path /~racnec-nomsut-rovwyx-bilmud--locdyr-samhet-ridbud-daplyd
%urb-watcher: on-watch on path /~sonhep-bisdet-tilnec-fogput--dolbur-livdun-matmet-daplyd
%urb-watcher: on-watch on path /~padwep-patruc-nisluc-fiddeb--rithec-dismyl-locweb-daplyd
%urb-watcher: on-watch on path /~noplyx-walhul-rinter-taprym--mocnup-matzod-somwex-daplyd
%urb-watcher: on-watch on path /~bosper-davrus-mocsef-digdeb--ravpyl-napner-sorwed-daplyd
%urb-watcher: on-watch on path /~nodpem-mapwyl-rocbec-forleb--somdes-sarwel-fabten-daplyd
%urb-watcher: on-watch on path /~minryl-racryt-miswyx-miptul--nactec-raptyr-hosref-daplyd
%urb-watcher: on-watch on path /~wolrut-torbur-nattyp-dozsut--riplug-ronreg-libnyx-daplyd
%urb-watcher: on-watch on path /~pitdus-tarryx-fadsup-sablep--linwyt-salbyn-batpun-daplyd
%urb-watcher: on-watch on path /~tagbyn-topsef-ragluc-harnex--tasryd-bosdul-watfep-daplyd
%urb-watcher: on-watch on path /~natser-timmel-fidpet-hidtex--tollen-lodnys-mogfex-daplyd
%urb-watcher: on-watch on path /~sigpeg-winwen-ropweg-midren--lidtug-patfun-sibfyr-daplyd
%urb-watcher: on-watch on path /~sorrud-witpet-foghex-tonten--tasnus-nispes-lagnex-daplyd
%urb-watcher: on-watch on path /~timtyp-patnyr-sogler-bacbyn--sarryt-dirsev-rabdys-daplyd
%urb-watcher: on-watch on path /~lapdyr-hosner-silhul-danlyr--fignet-ripfen-rinren-daplyd
%urb-watcher: on-watch on path /~dozfyn-banpen-firdev-maspec--talluc-winmer-ridput-daplyd
%urb-watcher: on-watch on path /~walnup-bonpet-finnel-hosluc--ticwyn-norlur-ribtec-daplyd
%urb-watcher: on-watch on path /~natnux-natdur-hanter-fasrul--donmep-nomtyl-sablun-daplyd
%urb-watcher: on-watch on path /~bolwyd-hidmut-timfex-fammed--noclun-woldyt-sibsem-daplyd
%urb-watcher: on-watch on path /~witrud-picmeb-mippec-fonwen--bicrem-modwet-mogheb-daplyd
%urb-watcher: on-watch on path /~bidryp-linrev-rosbex-novpur--modtyn-mirwyt-fosnum-daplyd
%urb-watcher: on-watch on path /~sibbet-lagber-hocwes-pilbec--hastun-dibpem-nodreg-daplyd
%urb-watcher: on-watch on path /~ridmeg-fambyl-lannep-lismes--lidtev-ramnum-filput-daplyd
%urb-watcher: on-watch on path /~hopweb-nossep-macsum-dasted--noslug-tolnum-nomlec-daplyd
%urb-watcher: on-watch on path /~rigner-mirfes-saltuc-lidlex--fosmyn-todmeg-forrup-daplyd
%urb-watcher: on-watch on path /~palset-paldev-wallev-tonrum--tocdeg-natnyx-panryp-daplyd
%urb-watcher: on-watch on path /~sopnex-mitnel-rildyt-fogreg--daldev-ragder-partud-daplyd
%urb-watcher: on-watch on path /~mitrum-nalnus-docteg-nidbex--fidzod-batsel-sittel-daplyd
%urb-watcher: on-watch on path /~silnex-masrex-naclev-pacden--ricwer-mipdeg-dactug-daplyd
%urb-watcher: on-watch on path /~lopdeg-sapben-rilmyr-hacwep--wicryc-tirter-hoctyr-daplyd
%urb-watcher: on-watch on path /~hasren-padful-monlur-hoptex--dirwyt-tobrut-sonlyd-daplyd
%urb-watcher: on-watch on path /~hacpem-niswyx-livryg-fodsun--lidlyr-martyr-ronfed-daplyd
%urb-watcher: on-watch on path /~dilfyr-misryt-wathex-rapfus--socrem-barsup-samryc-daplyd
%urb-watcher: on-watch on path /~dirdur-rocfet-wictul-nolsyl--fopnyt-bonfus-fortuc-daplyd
%urb-watcher: on-watch on path /~mitlet-wacset-ralhex-pocled--todlus-fitmun-silruc-daplyd
%urb-watcher: on-watch on path /~tapweb-silryg-noplen-minseb--savdec-tinseb-bisnub-daplyd
%urb-watcher: on-watch on path /~radnex-tagpel-lomnys-batrex--havsyn-namhes-milnes-daplyd
%urb-watcher: on-watch on path /~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd
%urb-watcher: on-watch on path /~lannec-lapnec-tombyn-dassem--hattud-formyr-talmyr-daplyd
%urb-watcher: on-watch on path /~soglur-sidsed-siddus-ronpel--battyc-radfel-fashes-daplyd
%urb-watcher: on-watch on path /~patnyx-navpeg-dotlux-tomnum--tonnec-fiptul-donrep-daplyd
%urb-watcher: on-watch on path /~pasped-dozter-lasfyn-motdur--falseg-togmun-sovlyn-daplyd
%urb-watcher: on-watch on path /~sivrup-napleb-mirmur-balmud--hilpen-borrym-navsec-daplyd
ames: lamp ~rovlur-namryp-barsup-dacdyt--randux-passeg-hopbel-daplyd static ip .1.2.3.4 port 12345
ames: lamp ~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd static ip .143.198.70.9 port 59344
ames: lamp ~patnyx-navpeg-dotlux-tomnum--tonnec-fiptul-donrep-daplyd static ip .1.2.3.4 port 12345
```

```
.^((unit point:jael) %j /=pynt=/~sivrup-napleb-mirmur-balmud--hilpen-borrym-navsec-daplyd)
[ ~
  [ rift=0
    life=1
      keys
    [   n
      [ p=1
          q
        [ crypto-suite=2
            pass
          174.470.297.796.729.812.110.376.021.501.776.316.522.344.993.111.608.272.416.252.967.932.357.444.706.930.851.029.211.727.701.047.298.959.289.343.153.703.291.381.746.296.485.513.783.959.698.422.862.615.750.615.773.599.039.231.921.412.159.047.802.045.068.703.679.142.903.362.321.827.597.514.255.906.872.994.713.803.276.129.562.947.262.987.499.552.709.880.109.771.910.611.470.160.739
        ]
      ]
      l=~
      r=~
    ]
    sponsor=[~ ~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd]
    fief=~
  ]
]
```

```
.^(ship-state:ames %ax /=//=/peers/~sivrup-napleb-mirmur-balmud--hilpen-borrym-navsec-daplyd)|
bail: 4

bail: 2
dojo: failed to process input
```

Before merging this, I'd like to test this branch with snapshotting turned off to see if that fixes the Ames problem, and if so, if there's a bug in the snapshot processing logic which causes this Jael state to be incorrect.

