### PR TITLE
urb: turn off +verb

### DIFF
--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -29,7 +29,7 @@
 ^-  agent:gall
 =|  state-0
 =*  state  -
-%+  verb  &
+%+  verb  |
 =<
 |_  =bowl:gall
 +*  this   .


### PR DESCRIPTION
At this point it's more trouble than it's worth to keep this on by default. This can be toggled with an `:urb-watcher &verb %loud` poke if we need to inspect what's going on in there.