### PR TITLE
Replace snapshot system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ VENDOR_BASE_DEV_GW := \
 	mar/bill.hoon \
 	mar/kelvin.hoon \
 	mar/noun.hoon \
+	mar/jam.hoon \
 	mar/mime.hoon \
 	mar/hoon.hoon \
 	sur/asn1.hoon \

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,13 @@ $(ONBOARD_BIN): $(ONBOARD_VENV) $(ONBOARD_DIR)/gw-onboard.py
 		--hidden-import nacl.bindings \
 		--hidden-import embit.util.secp256k1 \
 		--hidden-import _cffi_backend \
+		--hidden-import bitstring.bitstore_bitarray \
+		--hidden-import bitstring.bitstore_bitarray_helpers \
+		--hidden-import bitstring.bitstore_common_helpers \
+		--hidden-import bitstring.bitstore_tibs \
+		--hidden-import bitstring.bitstore_tibs_helpers \
+		--hidden-import bitarray \
+		--hidden-import bitarray._bitarray \
 		gw-onboard.py
 	@echo "gw-onboard binary built at $(ONBOARD_BIN)"
 

--- a/groundwire/app/urb-snapshot.hoon
+++ b/groundwire/app/urb-snapshot.hoon
@@ -176,6 +176,7 @@
             "application/x-urb-jam\0a"
             (trip http-date)
             "\0a"
+            "x-amz-acl:public-read\0a"
             "/"
             (trip bucket.state)
             (trip object-path)
@@ -201,6 +202,7 @@
                     full-url
                     :~  ['Date' http-date]
                         ['Content-Type' 'application/x-urb-jam']
+                        ['x-amz-acl' 'public-read']
                         ['Authorization' authorization-v2]
                     ==
                     `body

--- a/groundwire/app/urb-snapshot.hoon
+++ b/groundwire/app/urb-snapshot.hoon
@@ -1,0 +1,214 @@
+/-  urb
+/+  dbug, verb, default-agent
+|%
++$  card  card:agent:gall
++$  versioned-state  $%(state-0)
+::
++$  state-0
+  $:  %0
+      end=@t
+      bucket=@t
+      region=@t
+      access-key=@t
+      secret-key=@t
+  ==
+::
++$  credentials-update
+  $:  access-key=(unit @t)
+      secret-key=(unit @t)
+  ==
+::
++$  config-update
+  $:  end=(unit @t)
+      bucket=(unit @t)
+      region=(unit @t)
+  ==
+--
+::
+%+  verb  |
+%-  agent:dbug
+=|  state-0
+=*  state  -
+^-  agent:gall
+|_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+::
+++  on-init
+  ^-  (quip card _this)
+  :_  this
+  :~  :*  %pass   /urb-watcher/update/urb-state
+          %agent  [our.bowl %urb-watcher]
+          %watch  /urb-state
+      ==
+  ==
+++  on-save  !>(state)
+++  on-load
+  |=  =vase
+  ^-  (quip card _this)
+  `this(state !<(state-0 vase))
+::
+++  on-poke
+  |=  [=mark =vase]
+  ^-  (quip card _this)
+  ?+    mark  (on-poke:def mark vase)
+      %set-config
+    =/  upd=config-update  !<(config-update vase)
+    :-  ~
+    %=  this
+      end     ?~(end.upd end.state u.end.upd)
+      bucket  ?~(bucket.upd bucket.state u.bucket.upd)
+      region  ?~(region.upd region.state u.region.upd)
+    ==
+  ::
+      %set-credentials
+    =/  upd=credentials-update  !<(credentials-update vase)
+    :-  ~
+    %=  this
+      access-key  ?~(access-key.upd access-key.state u.access-key.upd)
+      secret-key  ?~(secret-key.upd secret-key.state u.secret-key.upd)
+    ==
+  ==
+++  on-peek   on-peek:def
+++  on-watch  on-watch:def
+++  on-arvo
+  |=  [=(pole knot) =sign-arvo]
+  ^-  (quip card _this)
+  ?+    pole  (on-arvo:def pole sign-arvo)
+      [%upload hash=@ta ~]
+    ?+    sign-arvo  (on-arvo:def pole sign-arvo)
+        [%iris %http-response *]
+      =/  [%iris %http-response =client-response:iris]  sign-arvo
+      ?+    -.client-response  `this
+          %finished
+        =/  hit=httr:eyre
+          %-  to-httr:iris
+          [response-header.client-response full-file.client-response]
+        ?:  &((gte p.hit 200) (lth p.hit 300))
+          %-  (slog :_(~ [%leaf "%urb-snapshot: uploaded snapshot {<(@uv (slav %uv hash.pole))>}"]))
+          `this
+        ?~  full-file.client-response
+          %-  (slog :_(~ [%leaf "%urb-snapshot: upload failed ({<p.hit>}) {<(@uv (slav %uv hash.pole))>}"]))
+          `this
+        =/  body=@t  q.data.u.full-file.client-response
+        %-  (slog :_(~ [%leaf "%urb-snapshot: upload failed ({<p.hit>}) {<body>}"]))
+        `this
+      ::
+          %cancel
+        %-  (slog :_(~ [%leaf "%urb-snapshot: failed to upload snapshot {<(@uv (slav %uv hash.pole))>}"]))
+        `this
+      ==
+    ==
+  ==
+++  on-leave  on-leave:def
+++  on-agent
+  |=  [=(pole knot) =sign:agent:gall]
+  ^-  (quip card _this)
+  ?+    pole  (on-agent:def pole sign)
+      [%urb-watcher %update %urb-state ~]
+    ?+    -.sign  (on-agent:def pole sign)
+        %fact
+      ?+    p.cage.sign  (on-agent:def pole sign)
+          %urb-state
+        ?:  =('' end.state)
+          `this
+        =/  urb-state=state:urb  !<(state:urb q.cage.sign)
+        ::  XX sign the jammed urb-state with our private key
+        =/  jammed=@        (jam urb-state)
+        =/  content-length  (met 3 jammed)
+        =/  body=octs       [content-length jammed]
+        =/  now=@da         now.bowl
+        =/  dt              (yore now)
+        =/  zero-pad
+          |=  [wid=@ud n=@ud]
+          ^-  tape
+          =/  raw=tape  (a-co:co n)
+          =/  pad=@ud  ?:((gte (lent raw) wid) 0 (sub wid (lent raw)))
+          (weld (reap pad '0') raw)
+        =/  host=@t
+          (crip "{(trip bucket.state)}.{(trip region.state)}.{(trip end.state)}")
+        =/  object-path=@t
+          '/snapshot/urb-snapshot.jam'
+        =/  full-url=@t
+          (crip "https://{(trip host)}{(trip object-path)}")
+        =/  weekday
+          |=  d=@da
+          ^-  tape
+          =/  dow  (mod (div (sub d ~1970.1.1) ~d1) 7)
+          =/  days=(list tape)
+            ~["Thu" "Fri" "Sat" "Sun" "Mon" "Tue" "Wed"]
+          (snag dow days)
+        =/  month-name
+          |=  m=@ud
+          ^-  tape
+          =/  months=(list tape)
+            ~["Jan" "Feb" "Mar" "Apr" "May" "Jun" "Jul" "Aug" "Sep" "Oct" "Nov" "Dec"]
+          (snag (dec m) months)
+        =/  http-date=@t
+          %-  crip
+          ;:  welp
+            (weekday now)
+            ", "
+            (zero-pad 2 d.t.dt)
+            " "
+            (month-name m.dt)
+            " "
+            (a-co:co y.dt)
+            " "
+            (zero-pad 2 h.t.dt)
+            ":"
+            (zero-pad 2 m.t.dt)
+            ":"
+            (zero-pad 2 s.t.dt)
+            " GMT"
+          ==
+        =/  hmac-sha1-cord
+          |=  [key=@t msg=@t]
+          ^-  @
+          %-  hmac-sha1l:hmac:crypto
+          :-  [(met 3 key) (swp 3 key)]
+          [(met 3 msg) (swp 3 msg)]
+        =/  string-to-sign-v2=@t
+          %-  crip
+          ;:  welp
+            "PUT\0a"
+            "\0a"
+            "application/x-urb-jam\0a"
+            (trip http-date)
+            "\0a"
+            "/"
+            (trip bucket.state)
+            (trip object-path)
+          ==
+        =/  mac-v2=@  (hmac-sha1-cord secret-key.state string-to-sign-v2)
+        =/  signature-v2=@t
+          %-  en:base64:mimes:html
+          [20 (swp 3 mac-v2)]
+        =/  authorization-v2=@t
+          %-  crip
+          ;:  welp
+            "AWS "
+            (trip access-key.state)
+            ":"
+            (trip signature-v2)
+          ==
+        :_  this
+        :~  :*  %pass  /upload/(scot %uv (cut 5 [0 1] jammed))
+                %arvo  %i
+                %request
+                :_  *outbound-config:iris
+                :*  %'PUT'
+                    full-url
+                    :~  ['Date' http-date]
+                        ['Content-Type' 'application/x-urb-jam']
+                        ['Authorization' authorization-v2]
+                    ==
+                    `body
+                ==
+            ==
+        ==
+      ==
+    ==
+  ==
+++  on-fail   on-fail:def
+--

--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -13,11 +13,10 @@
 ::  You may want to change block-confirmations as well.
 ::
 /-  bitcoin, spider, ord, urb
-/+  bc=bitcoin, btcio, dbug, default-agent, uc=urb-core, strandio, verb, server
+/+  bc=bitcoin, btcio, dbug, default-agent, uc=urb-core, strandio, verb
 ::
 |%
 +$  card  card:agent:gall
-+$  versioned-state  $%(state-0)
 +$  state-0
   $:  %0
       rpc=req-to:btcio
@@ -35,35 +34,14 @@
 +*  this   .
     def    ~(. (default-agent this %|) bowl)
 ::
-::  Tell Jael to subscribe to us for PKI updates,
-::  initialize an urb-core, start a thread to
-::  fetch and process the first batch of blocks,
-::  and start a timer to fetch again.
 ++  on-init
   ^-  (quip card _this)
-  =/  new-rpc  ['https://alpha.groundwire.dev/rpc' [%basic 'mainnetrpcuser:fc3d36ce83e15484e75a658b2a9a8a90a66f4cb017ace74c8631fe082b93adbf']]
-  =/  start-height  943.140
-  =/  start-hash    0x1.62b3.04e4.d48c.3a53.d80a.96de.0210.d325.c0a9.a464.8b3c
-  =/  new-urb-state
-    :*  [start-hash start-height]
-        *sont-map:ord
-        *insc-ids:ord
-        *unv-ids:urb
-    ==
-  ::  Short-term performance hack: request a snapshot from the default sponsor.
-  :_  this(rpc new-rpc, urb-state new-urb-state)
-  ?:  =(our.bowl ~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd)
-    :~  :*  %pass  /blocks  %arvo  %k
-            %lard  q.byk.bowl
-            (get-blocks new-rpc new-urb-state)
-        ==  
-        :*  %pass  /eyre/connect  %arvo  %e 
-            %connect  `/apps/urb-watcher  dap.bowl
-        ==  
-    ==
-  ::  The snapshot HTTP request fails from ++on-init when we include the %groundwire
-  ::  desk in a pill. We send it a few seconds later to get around this. %azimuth does this too.
-  :~  [%pass /init/snapshot %arvo %b %wait (add ~s10 now.bowl)]
+  :-  ~
+  %=  this
+     rpc  :*  'https://alpha.groundwire.dev/rpc'
+              %basic
+              'mainnetrpcuser:fc3d36ce83e15484e75a658b2a9a8a90a66f4cb017ace74c8631fe082b93adbf'
+          ==
   ==
 ::
 ++  on-save
@@ -73,38 +51,27 @@
 ++  on-load
   |=  =vase
   ^-  (quip card _this)
-  =/  old  !<(versioned-state vase)
-  ?-    -.old
-      %0
-    :_  this(state old)
-    ::  This wasn't bound in our first deployment:
-    :~  :*  %pass  /eyre/connect  %arvo  %e 
-            %connect  `/apps/urb-watcher  dap.bowl
-        ==  
-    ==
-  ==
+  `this(state !<(state-0 vase))
 ::
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card _this)
   ?+    mark  !!
-      %handle-http-request
-    =+  !<([eyre-id=@ta =inbound-request:eyre] vase)
-    =/  ,request-line:server
-      (parse-request-line:server url.request.inbound-request)
-    ?+    method.request.inbound-request  !!
-        %'GET'
-      ?+    site  !!
-          [%apps %urb-watcher %snapshot ~]
-        ::  XX should sign the snapshot with +sign:as:cic
-        ::     if this is more than a short-term hack
-        :_  this
-        %+  give-simple-payload:app:server
-          eyre-id
-        ^-  simple-payload:http
-        :_  `(as-octs:mimes:html (jam urb-state))
-        [200 ~[['content-type' 'application/x-urb-jam']]]
+      %urb-start-indexing
+    =/  start-urb  !<((unit state:urb) vase)
+    ?~  start-urb
+      :_  this(urb-state default-urb-state)
+      :~  :*  %pass  /timer
+              %arvo  %b
+              %wait  now.bowl
+          ==
       ==
+    :_  this(urb-state u.start-urb)
+    :~  (listen-to-urb ~(key by unv-ids.u.start-urb) [%| dap.bowl])
+        :*  %pass  /timer
+            %arvo  %b
+            %wait  (add ~s30 now.bowl)
+        ==
     ==
   ==
 ::
@@ -127,13 +94,24 @@
     ::
       [%x %points ~]
     ``urb-points+!>(unv-ids.urb-state)
+    ::  /x/urb-state — entire urb-state for snapshots
+    ::
+      [%x %urb-state ~]
+    ``noun+!>(urb-state)
   ==
 ::
 ++  on-watch
   |=  =(pole knot)
   ^-  (quip card _this)
   ?+    pole  (on-watch:def pole)
-      [%http-response *]  `this
+  ::
+  ::  %urb-snapshot listens for new urb-states
+      [%urb-state ~]
+    :_  this
+    :~  :*  %give  %fact  ~
+            %noun  !>(urb-state)
+        ==
+    ==
   ::
   ::  Jael subscribes to / (aka ~) if it hears
   ::  that this agent is the default PKI source
@@ -165,66 +143,19 @@
   ^-  (quip card _this)
   ?+    wire  (on-arvo:def wire sign-arvo)
   ::
-  ::  Send the iris snapshot request now that
-  ::  the agent is fully initialized.
-      [%init %snapshot ~]
-    ?.  ?=([%behn %wake *] sign-arvo)  (on-arvo:def wire sign-arvo)
-    ?^  error.sign-arvo
-      %-  (slog :_(~ [%leaf "%urb-watcher: /init/snapshot timer error"]))
-      `this
-    %-  (slog :_(~ [%leaf "%urb-watcher: requesting a snapshot from the default sponsor"]))
-    :_  this
-    :~  :*  %pass  /snapshot
-            %arvo  %i
-            %request
-            ^-  request:http
-            :*  %'GET'
-                'http://143.198.70.9:8081/apps/urb-watcher/snapshot'
-                :~  ['accept' 'application/x-urb-jam']
-                ==
-                ~
-            ==
-            *outbound-config:iris
-        ==
-    ==
-  ::
   ::  Run +get-blocks at regular intervals.
       [%timer ~]
     :_  this
     :~  :*  %pass  /blocks  %arvo  %k
             %lard  q.byk.bowl
             (get-blocks [rpc urb-state]:state)
-        == 
-    ==
-  ::
-  ::  Receive a snapshot from the default sponsor
-  ::  containing an urb-state and tell Jael to subscribe
-  ::  to %urb-watcher for udiffs for each ship in that
-  ::  urb-state, which we'll fulfill immediately in ++on-agent.
-  ::  Now start indexing ourselves.
-      [%snapshot ~]
-    ?.  ?=([%iris %http-response *] sign-arvo)  [(snapshot-fail bowl) this]
-    =/  response  client-response.sign-arvo
-    ?+    -.response  [(snapshot-fail bowl) this]
-        %finished
-      ?~  full-file.response  [(snapshot-fail bowl) this]
-      =/  =mime-data:iris  u.full-file.response
-      ?+    type.mime-data  [(snapshot-fail bowl) this]
-          %'application/x-urb-jam'
-        ::  XX if we implement signed snapshots,
-        ::     verify here with +sure:as:cic
-        =/  new-urb=state:urb  ;;(state:urb (cue q.data.mime-data))
-        %-  (slog :_(~ [%leaf "%urb-watcher: processing groundwire snapshot ({<~(wyt by unv-ids.new-urb)>} points)"]))
-        :_  this(urb-state new-urb)
-        :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
-            (listen-to-urb ~(key by unv-ids:new-urb) [%| dap.bowl])
         ==
-      ==
     ==
   ::
   ::  Our +get-blocks thread returned. Update
-  ::  urb-state, emit udiffs to Jael, and set a timer
-  ::  to run the thread again.
+  ::  urb-state, emit udiffs to Jael and full
+  ::  urb-state snapshots to /urb-state watchers,
+  ::  and set a timer to run the thread again.
       [%blocks ~]
     ?+    sign-arvo  (on-arvo:def wire sign-arvo)
         [%khan %arow *]
@@ -278,8 +209,8 @@
         ?.  (~(has in tracked-ships) ship)
           ~
         `[ship udiff]
-      ::
-      :_  this(urb-state.state +.fx-and-state)
+      =/  new-urb-state  +.fx-and-state
+      :_  this(urb-state.state new-urb-state)
       %+  welp
         ?.  =(~ fx-ships)
           ::  don't send a %listen task for ships
@@ -289,7 +220,10 @@
               [%| dap.bowl]
           ==
         ~
-      :-  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
+      %+  welp
+        :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
+            [%give %fact ~[/urb-state] %noun !>(new-urb-state)]
+        ==
       (jael-update filtered-udiffs)
     ==
   ==
@@ -300,14 +234,17 @@
 --
 ::
 |%
-++  snapshot-fail
-  |=  =bowl:gall
-  %-  (slog :_(~ [%leaf "%urb-watcher's request for a snapshot failed. Beginning self-chain-watching"]))
-  ^-  (list card)
-  :~  :*  %pass  /blocks  %arvo  %k
-          %lard  q.byk.bowl
-          (get-blocks [rpc urb-state]:state)
-      == 
+::
+::  Hard-coded initial sync state used if
+::  %urb-start-indexing receives a null snapshot
+++  default-urb-state
+  ^-  state:urb
+  =/  start-height  943.140
+  =/  start-hash    0x1.62b3.04e4.d48c.3a53.d80a.96de.0210.d325.c0a9.a464.8b3c
+  :*  [start-hash start-height]
+      *sont-map:ord
+      *insc-ids:ord
+      *unv-ids:urb
   ==
 ::
 ::  Fetch blocks in range(last-processed + 1, latest - block-confirmations)

--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -60,12 +60,14 @@
       %urb-start-indexing
     =/  start-urb  !<((unit state:urb) vase)
     ?~  start-urb
+      %-  (slog :_(~ [%leaf "%urb-watcher: indexing from block {<num.block-id.default-urb-state>}"]))
       :_  this(urb-state default-urb-state)
       :~  :*  %pass  /timer
               %arvo  %b
               %wait  now.bowl
           ==
       ==
+    %-  (slog :_(~ [%leaf "%urb-watcher: processing groundwire snapshot ({<~(wyt by unv-ids.u.start-urb)>} points)"]))
     :_  this(urb-state u.start-urb)
     :~  (listen-to-urb ~(key by unv-ids.u.start-urb) [%| dap.bowl])
         :*  %pass  /timer

--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -58,9 +58,9 @@
   ^-  (quip card _this)
   ?+    mark  !!
       %urb-start-indexing
-    =/  start-urb  !<((unit state:urb) vase)
+    =/  start-urb  ;;((unit state:urb) !<((unit noun) vase))
     ?~  start-urb
-      %-  (slog :_(~ [%leaf "%urb-watcher: indexing from block {<num.block-id.default-urb-state>}"]))
+      %-  (slog :_(~ [%leaf "%urb-watcher: indexing from block {<num.block-id:(state:urb default-urb-state)>}"]))
       :_  this(urb-state default-urb-state)
       :~  :*  %pass  /timer
               %arvo  %b

--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -111,7 +111,7 @@
       [%urb-state ~]
     :_  this
     :~  :*  %give  %fact  ~
-            %noun  !>(urb-state)
+            %urb-state  !>(urb-state)
         ==
     ==
   ::
@@ -224,7 +224,11 @@
         ~
       %+  welp
         :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
-            [%give %fact ~[/urb-state] %noun !>(new-urb-state)]
+        ==
+      %+  welp
+        ?:  =(~ -.fx-and-state)
+          ~
+        :~  [%give %fact ~[/urb-state] %urb-state !>(new-urb-state)]
         ==
       (jael-update filtered-udiffs)
     ==

--- a/groundwire/desk.bill
+++ b/groundwire/desk.bill
@@ -1,3 +1,4 @@
 :~  %reg-tester
     %urb-watcher
+    %urb-snapshot
 ==

--- a/groundwire/mar/set-config.hoon
+++ b/groundwire/mar/set-config.hoon
@@ -1,0 +1,11 @@
+|_  update=[url=(unit @t) bucket=(unit @t) region=(unit @t)]
+++  grab
+  |%
+  ++  noun  [url=(unit @t) bucket=(unit @t) region=(unit @t)]
+  --
+++  grow
+  |=  =update
+  ^-  vase
+  !>(update)
+++  grad  %noun
+--

--- a/groundwire/mar/set-credentials.hoon
+++ b/groundwire/mar/set-credentials.hoon
@@ -1,0 +1,11 @@
+|_  update=[url=(unit @t) access-key=(unit @t) secret-key=(unit @t)]
+++  grab
+  |%
+  ++  noun  [url=(unit @t) access-key=(unit @t) secret-key=(unit @t)]
+  --
+++  grow
+  |=  =update
+  ^-  vase
+  !>(update)
+++  grad  %noun
+--

--- a/groundwire/mar/urb/start-indexing.hoon
+++ b/groundwire/mar/urb/start-indexing.hoon
@@ -1,0 +1,12 @@
+/-  urb
+|_  urb-state=(unit state:urb)
+++  grab
+  |%
+  ++  noun  (unit state:urb)
+  --
+++  grow
+  |%
+  ++  noun  urb-state
+  --
+++  grad  %noun
+--

--- a/groundwire/mar/urb/state.hoon
+++ b/groundwire/mar/urb/state.hoon
@@ -1,0 +1,12 @@
+/-  urb
+|_  urb-state=state:urb
+++  grab
+  |%
+  ++  noun  state:urb
+  --
+++  grow
+  |%
+  ++  noun  urb-state
+  --
+++  grad  %noun
+--

--- a/onboarding/booting/gw-onboard.py
+++ b/onboarding/booting/gw-onboard.py
@@ -90,6 +90,9 @@ SPONSOR_URL = "http://143.198.70.9:8081"
 SPONSOR_SHIP = "~daplyd"  # star — comet mines under this
 ESCAPE_SPONSOR = "~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd"  # networking sponsor for escape
 BLOCK_CONFIRMATIONS = 2
+SNAPSHOT_URL = "https://groundwire.io/snapshot"
+
+from pynoun import noun as pynoun
 
 
 # =========================================================================
@@ -1367,6 +1370,153 @@ def send_fyrd(vere_bin: str, conn_sock: str, fyrd_hoon: str) -> str:
     return dec.stdout.decode(errors="replace")
 
 
+def _snapshot_file_to_noun_literal(data: bytes) -> str:
+    """Convert jam bytes to a Hoon noun literal, validating with pynoun."""
+    jam_atom = int.from_bytes(data, "little") if data else 0
+    noun_value = pynoun.cue(jam_atom)
+    # Some snapshot sources provide jam(jam(state:urb)); unwrap nested jam atoms.
+    for _ in range(3):
+        if not isinstance(noun_value, int):
+            break
+        noun_value = pynoun.cue(noun_value)
+    if isinstance(noun_value, int):
+        raise ValueError("Snapshot did not decode to a state noun")
+    return _hoon_noun_with_dotted_atoms(noun_value)
+
+
+def _format_dotted_decimal_atom(value: int) -> str:
+    """Format a decimal atom with dots every 3 digits."""
+    s = str(value)
+    if len(s) <= 3:
+        return s
+    first = len(s) % 3
+    if first == 0:
+        first = 3
+    out = [s[:first]]
+    for i in range(first, len(s), 3):
+        out.append(s[i:i + 3])
+    return ".".join(out)
+
+
+def _hoon_noun_with_dotted_atoms(n, tail_pos: bool = False) -> str:
+    """Render a pynoun noun using Hoon list syntax with dotted decimal atoms."""
+    if isinstance(n, int):
+        return _format_dotted_decimal_atom(n)
+    if isinstance(n, pynoun.Cell):
+        content = f"{_hoon_noun_with_dotted_atoms(n.head, False)} {_hoon_noun_with_dotted_atoms(n.tail, True)}"
+        return content if tail_pos else f"[{content}]"
+    raise TypeError(f"Unsupported noun type: {type(n)!r}")
+
+
+def load_snapshot_file(local_path: str | None, remote_url: str = SNAPSHOT_URL) -> bytes | None:
+    """Load snapshot.jam from local file or remote URL.
+
+    Returns raw jam bytes, or None if remote fetch fails.
+    """
+    if local_path:
+        try:
+            with open(local_path, "rb") as f:
+                data = f.read()
+        except OSError as e:
+            print(f"ERROR: Could not read snapshot jam file: {local_path}")
+            print(e)
+            sys.exit(1)
+        if not data:
+            print(f"ERROR: Snapshot jam file is empty: {local_path}")
+            sys.exit(1)
+        try:
+            _snapshot_file_to_noun_literal(data)
+        except Exception as e:
+            print(f"ERROR: Snapshot jam file is not valid Urbit jam: {local_path}")
+            print(e)
+            sys.exit(1)
+        print(f"Using local snapshot jam: {local_path}")
+        return data
+
+    for attempt in range(1, 4):
+        try:
+            resp = requests.get(remote_url, timeout=20)
+            if resp.ok and resp.content:
+                try:
+                    _snapshot_file_to_noun_literal(resp.content)
+                except Exception:
+                    if attempt < 3:
+                        time.sleep(2)
+                    continue
+                print(f"Fetched snapshot jam from {remote_url}")
+                return resp.content
+        except Exception:
+            pass
+        if attempt < 3:
+            time.sleep(2)
+
+    print(f"WARNING: Could not fetch snapshot jam from {remote_url}; will start indexing without snapshot.")
+    return None
+
+
+def make_snapshot_fyrd(snapshot_file: bytes) -> str:
+    """Build a FYRD that pokes %urb-watcher with (unit state:urb)."""
+    cued_snapshot = _snapshot_file_to_noun_literal(snapshot_file)
+    # print("cued snapshot:")
+    # print(f"{cued_snapshot}")
+    return f""":*  0
+                    %fyrd
+                    %base
+                    %khan-eval
+                    %noun
+                    %ted-eval
+                    :_  :~  /sur/spider/hoon
+                            /lib/strandio/hoon
+                        ==
+                    '''
+                    =/  m  (strand ,vase)
+                    ::  XX verify signed jamfile
+                    ;<  our=ship  bind:m  get-our
+                    ;<  ~  bind:m
+                      %-  send-raw-card
+                      :*  %pass   /start-indexing
+                          %agent  [our %urb-watcher]
+                          %poke   %urb-start-indexing
+                          !>((some {cued_snapshot}))
+                      ==
+                    ;<  ~  bind:m  (take-poke-ack /start-indexing)
+                    (pure:m !>(~))
+                    '''
+                =="""
+
+
+_START_INDEXING_NO_SNAPSHOT = """:*  0
+                                  %fyrd
+                                  %base
+                                  %khan-eval
+                                  %noun
+                                  %ted-eval
+                                  :_  :~  /sur/spider/hoon
+                                          /lib/strandio/hoon
+                                      ==
+                                  '''
+                                  =/  m  (strand ,vase)
+                                  ;<  ~  bind:m
+                                    %:  poke-our
+                                        %urb-watcher
+                                        %urb-start-indexing
+                                        !>(~)
+                                    ==
+                                  (pure:m !>(~))
+                                  '''
+                              =="""
+
+
+def start_indexing_from_snapshot(vere_bin: str, conn_sock: str, snapshot_file: bytes | None) -> None:
+    """Poke %urb-watcher to start %urb-watcher indexing."""
+
+    if snapshot_file is not None:
+        send_fyrd(vere_bin, conn_sock, make_snapshot_fyrd(snapshot_file))
+        return
+
+    send_fyrd(vere_bin, conn_sock, _START_INDEXING_NO_SNAPSHOT)
+
+
 _IDLE_FYRD = """:*  0
                     %fyrd
                     %base
@@ -1555,7 +1705,13 @@ def print_boot_success(url: str, master_ticket: str, pier_name: str) -> None:
     # print("2. Say hi in the Groundwire Foundation group on Tlon")
 
 
-def boot_comet(comet_name: str, feed: str, vere_bin: str, pill: str = GW_PILL) -> str:
+def boot_comet(
+    comet_name: str,
+    feed: str,
+    vere_bin: str,
+    pill: str = GW_PILL,
+    snapshot_file: bytes | None = None,
+) -> str:
     """Boot a comet, wait until idle, kill the process, then return the local URL.
 
     Starts vere, polls conn.sock until the ship responds to a FYRD, then waits
@@ -1612,10 +1768,13 @@ def boot_comet(comet_name: str, feed: str, vere_bin: str, pill: str = GW_PILL) -
     proc, crash_event, mcp_event, landscape_event, nostrill_event = _start_proc(cmd)
     _wait_for_sock(proc)
     wait_for_idle(vere_bin, conn_sock)
-    send_fyrd(vere_bin, conn_sock, _INSTALL_GW_APPS)
+    time.sleep(30)
+    start_indexing_from_snapshot(vere_bin, conn_sock, snapshot_file)
+    # send_fyrd(vere_bin, conn_sock, _INSTALL_GW_APPS)
 
     # Track desk installations across potential restarts
-    installed = {"mcp": False, "landscape": False, "nostrill": False}
+    installed = {"mcp": True, "landscape": True, "nostrill": True}
+    # installed = {"mcp": False, "landscape": False, "nostrill": False}
 
     # Wait for all desks to install; restart if vere crashes with Ames bad-packet.
     while True:
@@ -1708,8 +1867,15 @@ def main():
         action="store_true",
         help="Skip all funding and attestation steps — mines and boots the comet without a Bitcoin transaction",
     )
+    parser.add_argument(
+        "--snapshot-file",
+        default=None,
+        help="Path to local snapshot.jam file (skips remote fetch from groundwire.io)",
+    )
 
     args = parser.parse_args()
+
+    snapshot_file = load_snapshot_file(args.snapshot_file)
 
     # Parse --fief flag (ip:port)
     fief = None
@@ -1852,7 +2018,7 @@ def main():
             print(step_header(f"Step 4/{total_steps}: Booting your ship"))
             print()
             print("Give it a second...")
-            url = boot_comet(comet, feed, args.vere)
+            url = boot_comet(comet, feed, args.vere, snapshot_file=snapshot_file)
             print_boot_success(url, master_ticket, pier_name=comet.lstrip("~"))
         return
 
@@ -1945,7 +2111,7 @@ def main():
         print(step_header(f"Step {total_steps}/{total_steps}: Booting your ship"))
         print()
         print("Give it a second...")
-        url = boot_comet(comet, feed, args.vere)
+        url = boot_comet(comet, feed, args.vere, snapshot_file=snapshot_file)
         print_boot_success(url, master_ticket, pier_name)
 
 if __name__ == "__main__":

--- a/onboarding/booting/gw-onboard.py
+++ b/onboarding/booting/gw-onboard.py
@@ -90,7 +90,7 @@ SPONSOR_URL = "http://143.198.70.9:8081"
 SPONSOR_SHIP = "~daplyd"  # star — comet mines under this
 ESCAPE_SPONSOR = "~linluc-palnus-barpub-dalweg--miptyp-molfer-pitren-daplyd"  # networking sponsor for escape
 BLOCK_CONFIRMATIONS = 2
-SNAPSHOT_URL = "https://groundwire.io/snapshot"
+DEFAULT_SNAPSHOT_URL = "https://groundwire.nyc3.cdn.digitaloceanspaces.com/snapshot/urb-snapshot.jam"
 
 from pynoun import noun as pynoun
 
@@ -1408,7 +1408,7 @@ def _hoon_noun_with_dotted_atoms(n, tail_pos: bool = False) -> str:
     raise TypeError(f"Unsupported noun type: {type(n)!r}")
 
 
-def load_snapshot_file(local_path: str | None, remote_url: str = SNAPSHOT_URL) -> bytes | None:
+def load_snapshot_file(local_path: str | None, snapshot_url: str = DEFAULT_SNAPSHOT_URL) -> bytes | None:
     """Load snapshot.jam from local file or remote URL.
 
     Returns raw jam bytes, or None if remote fetch fails.
@@ -1435,22 +1435,26 @@ def load_snapshot_file(local_path: str | None, remote_url: str = SNAPSHOT_URL) -
 
     for attempt in range(1, 4):
         try:
-            resp = requests.get(remote_url, timeout=20)
+            print(f"Fetching snapshot from {snapshot_url}")
+            resp = requests.get(snapshot_url, timeout=120)
             if resp.ok and resp.content:
                 try:
                     _snapshot_file_to_noun_literal(resp.content)
-                except Exception:
+                except Exception as e:
+                    print(f"  Failed to deserialize snapshot: {e}")
                     if attempt < 3:
                         time.sleep(2)
                     continue
-                print(f"Fetched snapshot jam from {remote_url}")
+                print("Fetched snapshot")
                 return resp.content
-        except Exception:
-            pass
+            else:
+                print(f"  HTTP {resp.status_code}")
+        except Exception as e:
+            print(f"  Download failed: {e}")
         if attempt < 3:
             time.sleep(2)
 
-    print(f"WARNING: Could not fetch snapshot jam from {remote_url}; will start indexing without snapshot.")
+    print(f"Could not fetch snapshot from {snapshot_url}; indexing without snapshot.")
     return None
 
 
@@ -1872,10 +1876,20 @@ def main():
         default=None,
         help="Path to local snapshot.jam file (skips remote fetch from groundwire.io)",
     )
+    parser.add_argument(
+        "--snapshot-url",
+        default=DEFAULT_SNAPSHOT_URL,
+        help=f"URL to fetch snapshot from {DEFAULT_SNAPSHOT_URL}",
+    )
+    parser.add_argument(
+        "--pill",
+        default=GW_PILL,
+        help=f"Path to pill file for booting (default: {GW_PILL})",
+    )
 
     args = parser.parse_args()
 
-    snapshot_file = load_snapshot_file(args.snapshot_file)
+    snapshot_file = load_snapshot_file(args.snapshot_file, snapshot_url=args.snapshot_url)
 
     # Parse --fief flag (ip:port)
     fief = None
@@ -2018,7 +2032,7 @@ def main():
             print(step_header(f"Step 4/{total_steps}: Booting your ship"))
             print()
             print("Give it a second...")
-            url = boot_comet(comet, feed, args.vere, snapshot_file=snapshot_file)
+            url = boot_comet(comet, feed, args.vere, pill=args.pill, snapshot_file=snapshot_file)
             print_boot_success(url, master_ticket, pier_name=comet.lstrip("~"))
         return
 
@@ -2105,13 +2119,13 @@ def main():
         print(f"feed: {feed}")
         print()
         print("To boot manually later, run:")
-        print(f"{args.vere} -w {pier_name} -B {GW_PILL} -G {feed}")
+        print(f"{args.vere} -w {pier_name} -B {args.pill} -G {feed}")
     else:
         print()
         print(step_header(f"Step {total_steps}/{total_steps}: Booting your ship"))
         print()
         print("Give it a second...")
-        url = boot_comet(comet, feed, args.vere, snapshot_file=snapshot_file)
+        url = boot_comet(comet, feed, args.vere, pill=args.pill, snapshot_file=snapshot_file)
         print_boot_success(url, master_ticket, pier_name)
 
 if __name__ == "__main__":

--- a/onboarding/booting/gw-onboard.spec
+++ b/onboarding/booting/gw-onboard.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['gw-onboard.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['requests', 'nacl.bindings', 'embit.util.secp256k1', '_cffi_backend', 'bitstring.bitstore_bitarray', 'bitstring.bitstore_bitarray_helpers', 'bitstring.bitstore_common_helpers', 'bitstring.bitstore_tibs', 'bitstring.bitstore_tibs_helpers', 'bitarray', 'bitarray._bitarray'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='gw-onboard',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/onboarding/booting/pynoun/__init__.py
+++ b/onboarding/booting/pynoun/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored pynoun package."""

--- a/onboarding/booting/pynoun/noun.py
+++ b/onboarding/booting/pynoun/noun.py
@@ -1,0 +1,451 @@
+"""
+Urbit nouns with mug, jam, and cue.
+"""
+
+import mmh3
+from bitstring import BitArray
+
+def byte_length(i: int):
+    """how many bytes to represent i?
+
+    >>> byte_length(0)
+    0
+    >>> byte_length(255)
+    1
+    >>> byte_length(256)
+    2
+    """
+
+    lyn = i.bit_length()
+    byt = lyn >> 3
+    return byt + 1 if lyn & 7 else byt
+
+def intbytes(i: int):
+    """turn i into a (little endian) bytes object
+
+    >>> intbytes(0)
+    b''
+    >>> intbytes(256)
+    b'\\x00\\x01'
+    """
+
+    return i.to_bytes(byte_length(i), 'little', signed=False)
+
+def mum(syd: int, fal: int, key: int):
+    """try to hash key with syd, incrementing syd on zero
+    hash up to 8 times, falling back to fal.
+
+    >>> mum(0xcafebabe, 0x7fff, 0)
+    2046756072
+    >>> mum(0xdeadbeef, 0xfffe, 8790750394176177384)
+    422532488
+    """
+
+    k = intbytes(key)
+    for s in range(syd, syd+8):
+        haz = mmh3.hash(k, seed=s, signed=False)
+        ham = (haz >> 31) ^ (haz & 0x7fffffff)
+        if 0 != ham:
+            return ham
+    return fal
+
+def mug_both(one: int, two: int):
+    """mug from two other mugs (for cells)
+
+    >>> mug_both(2046756072, 2046756072)
+    422532488
+    """
+
+    return mum(0xdeadbeef, 0xfffe, (two << 32) | one)
+
+class Cell:
+    """A cell is an ordered pair of two nouns.
+    >>> x = Cell(1, Cell(2, 3))
+    >>> x.head
+    1
+    >>> x.tail.head
+    2
+    >>> x.tail.tail
+    3
+    """
+
+    def __init__(self, head, tail, mug=0):
+        self.head = head
+        self.tail = tail
+        self.mug = mug
+
+    def __hash__(self):
+        """31-bit non-zero murmur3 (mug)
+
+        >>> x = Cell(0, 0)
+        >>> x.mug
+        0
+        >>> hash(x)
+        422532488
+        >>> x.mug
+        422532488
+        """
+
+        if 0 == self.mug:
+            self.mug = mug_both(mug(self.head), mug(self.tail))
+        return self.mug
+
+    def __eq__(self, other):
+        """unifying equality: after comparing equal, cells share storage.
+
+        >>> x = Cell(Cell(1,2),Cell(3,4))
+        >>> y = Cell(Cell(1,2),Cell(3,4))
+        >>> hash(y)
+        1496649457
+        >>> x.head is y.head or x.tail is y.tail
+        False
+        >>> x == y
+        True
+        >>> x.head is y.head and x.tail is y.tail
+        True
+        >>> x.mug != 0 and x.mug == y.mug
+        True
+        """
+
+        if not deep(other):
+            return False
+        if self.mug != 0 and other.mug != 0 and self.mug != other.mug:
+            return False
+        if self.head != other.head:
+            return False
+        other.head = self.head
+        if self.tail != other.tail:
+            return False
+        other.tail = self.tail
+        if 0 != self.mug:
+            other.mug = self.mug
+        elif 0 != other.mug:
+            self.mug = other.mug
+        return True
+
+    def pretty(self, tail_pos):
+        """pretty print a cell in or out of tail position
+
+        >>> x = Cell(0, 0)
+        >>> x.pretty(False)
+        '[0 0]'
+        >>> x.pretty(True)
+        '0 0'
+        """
+
+        content = '%s %s' % \
+                (pretty(self.head, False), pretty(self.tail, True))
+        if tail_pos:
+            return content
+        return '[%s]' % content
+
+    def __str__(self):
+        return self.pretty(False)
+
+noun = int | Cell
+
+def deep(n: noun):
+    """test whether noun is a cell, like nock 3
+    
+    >>> deep(1)
+    False
+    >>> deep(Cell(1,2))
+    True
+    """
+    
+    return isinstance(n, Cell)
+
+def mug(n: noun):
+    """get the mug for any noun
+
+    >>> mug(0)
+    2046756072
+    >>> mug(Cell(0, 0))
+    422532488
+    """
+
+    if deep(n):
+        return hash(n)
+    return mum(0xcafebabe, 0x7fff, n)
+
+def pretty(n: noun, tail_pos:bool):
+    """pretty-print a noun, in or out of tail position.
+
+    >>> pretty(1, True)
+    '1'
+    >>> pretty(Cell(1,Cell(2,3)), False)
+    '[1 2 3]'
+    >>> pretty(Cell(Cell(1,2), 3), True)
+    '[1 2] 3'
+    """
+
+    if deep(n):
+        return n.pretty(tail_pos)
+    return str(n)
+
+def translate(seq):
+    """turn python sequences into tuples.
+
+    >>> str(translate([1,[2,3],4]))
+    '[1 [2 3] 4]'
+    """
+
+    def r(i, l):
+        if 1 == l:
+            return seq[i]
+        return Cell(translate(seq[i]), r(i+1, l-1))
+
+    if isinstance(seq, noun):
+        return seq
+    c = len(seq)
+    if 0 == c:
+        return 0
+    return r(0, c)
+
+def parse(s: str):
+    """parse strings into nouns. dots in atoms are ignored,
+    outermost braces can be omitted.
+
+    >>> parse('1.024')
+    1024
+    >>> x = parse('[[1 2] 3]')
+    >>> [x.head.head, x.head.tail, x.tail]
+    [1, 2, 3]
+    >>> x = parse('[1 2] 3')
+    >>> [x.head.head, x.head.tail, x.tail]
+    [1, 2, 3]
+    """
+
+    sep = True
+    start = 0
+    wait = []
+    top = (0, [])
+    num = []
+
+    def frame(i: int):
+        return (i, [])
+
+    def end_atom():
+        nonlocal sep
+        if not sep:
+            sep = True
+            top[1].append(int(''.join(num)))
+            num.clear()
+
+    def end_cell():
+        items = top[1]
+        count = len(items)
+        if 0 == count:
+            return 0
+        count -= 1
+        tail = items[count]
+        while count > 0:
+            count -= 1
+            tail = Cell(items[count], tail)
+        return tail
+
+    for i in range(0, len(s)):
+        c = s[i]
+        match c:
+            case '[':
+                end_atom()
+                wait.append(top)
+                top = frame(i)
+            case ']':
+                if not wait:
+                    raise ValueError('unmatched ] at %d' % i)
+                end_atom()
+                val = end_cell()
+                top = wait.pop()
+                top[1].append(val)
+            case ' ':
+                end_atom()
+            case '.':
+                if sep:
+                    raise ValueError('floating dot at %d' % i)
+            case _:
+                if not str.isdigit(c):
+                    raise ValueError('unrecognized character %s at %d' % (c, i))
+                else:
+                    if sep:
+                        start = i
+                        sep = False
+                    num.append(c)
+    if wait:
+        raise ValueError('unclosed [ at %d' % top[0])
+    end_atom()
+    return end_cell()
+
+def jam_to_stream(n: noun, out: BitArray):
+    """jam but put the bits into a stream
+
+    >>> s = BitArray()
+    >>> jam_to_stream(Cell(0,0), s)
+    >>> s
+    BitArray('0b100101')
+    """
+
+    cur = 0
+    refs = {}
+
+    def bit(b: bool):
+        nonlocal cur
+        out.append([b])
+        cur += 1
+
+    def zero():
+        bit(False)
+
+    def one():
+        bit(True)
+
+    def bits(num: int, count: int):
+        nonlocal cur
+        for i in range(0, count):
+            out.append([(num & (1 << i)) != 0])
+        cur += count
+
+    def save(a: noun):
+        refs[a] = cur
+
+    def mat(i: int):
+        if 0 == i:
+            one()
+        else:
+            a = i.bit_length()
+            b = a.bit_length()
+            above = b + 1
+            below = b - 1
+            bits(1 << b, above)
+            bits(a & ((1 << below) - 1), below)
+            bits(i, a)
+
+    def back(ref: int):
+        one()
+        one()
+        mat(ref)
+
+    def r(a: noun):
+        dupe = refs.get(a)
+        if deep(a):
+            if dupe:
+                back(dupe)
+            else:
+                save(a)
+                one()
+                zero()
+                r(a.head)
+                r(a.tail)
+        elif dupe:
+            isize = a.bit_length()
+            dsize = dupe.bit_length()
+            if isize < dsize:
+                zero()
+                mat(a)
+            else:
+                back(dupe)
+        else:
+            save(a)
+            zero()
+            mat(a)
+    r(n)
+
+def read_int(length: int, s: BitArray):
+    """read length bits from s and make a python integer.
+
+    >>> s = BitArray('0b001')
+    >>> read_int(3, s)
+    4
+    """
+
+    r = 0
+    for i in range(0, length):
+        r |= (1 if s[i] else 0) << i
+    return r
+
+def jam(n: noun):
+    """urbit serialization: * -> @
+
+    >>> jam(0)
+    2
+    >>> jam(Cell(0,0))
+    41
+    >>> jam(Cell(Cell(1234567890987654321,1234567890987654321), \\
+    ...          Cell(1234567890987654321,1234567890987654321)))
+    22840095095806892874257389573
+    """
+
+    out = BitArray()
+    jam_to_stream(n, out)
+    return read_int(len(out), out)
+
+def cue_from_stream(s: BitArray):
+    """cue but read the bits from a stream
+
+    >>> s = BitArray('0b01')
+    >>> cue_from_stream(s)
+    0
+    """
+
+    refs = {}
+    cur = 0
+    position = 0
+
+    def bits(n: int):
+        nonlocal cur, position
+        cur += n
+        result = 0
+        for i in range(n):
+            result |= (1 if s[position] else 0) << i
+            position += 1
+        return result
+
+    def one():
+        nonlocal cur, position
+        cur += 1
+        bit = s[position]
+        position += 1
+        return bit
+    
+    def rub():
+        z = 0
+        while not one():
+            z += 1
+        if 0 == z:
+            return 0
+        below = z - 1
+        lbits = bits(below)
+        bex = 1 << below
+        return bits(bex ^ lbits)
+
+    def r(start: int):
+        ret = None
+        if one():
+            if one():
+                ret = refs[rub()]
+            else:
+                hed = r(cur)
+                tal = r(cur)
+                ret = Cell(hed, tal)
+        else:
+            ret = rub()
+        refs[start] = ret
+        return ret
+    return r(cur)
+
+def cue(i: int):
+    """urbit deserialization: @ -> *
+
+    >>> str(cue(22840095095806892874257389573))
+    '[[1234567890987654321 1234567890987654321] 1234567890987654321 1234567890987654321]'
+    """
+
+    bits = BitArray()
+    while i > 0:
+        bits.append([i & 1 == 1])
+        i >>= 1
+    return cue_from_stream(bits)
+
+if '__main__' == __name__:
+    import doctest
+    doctest.testmod()

--- a/onboarding/booting/requirements.txt
+++ b/onboarding/booting/requirements.txt
@@ -1,3 +1,5 @@
 embit>=0.8.0
 PyNaCl>=1.5.0
 requests>=2.28.0
+bitstring>=4.0.0
+mmh3>=5.0.0


### PR DESCRIPTION
Storing the snapshot we use for onboarding on an Urbit is volatile because if that Urbit becomes irreparably broken, the snapshot is lost forever.

This PR adds an %urb-snapshot agent which periodically uploads snapshots to a configured S3 endpoint, which is more stable. This also refactors %urb-watcher and gw-onboard to parameratise the snapshot such that the snapshot location is only hard-coded in gw-onboard.

Review / merge in tandem with https://github.com/gwbtc/website/pull/20