### PR TITLE
Upload snapshot on each block

### DIFF
--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -223,14 +223,10 @@
           ==
         ~
       %+  welp
-        :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
-        ==
-      %+  welp
-        ?:  =(~ -.fx-and-state)
-          ~
-        :~  [%give %fact ~[/urb-state] %urb-state !>(new-urb-state)]
-        ==
-      (jael-update filtered-udiffs)
+        (jael-update filtered-udiffs)
+      :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
+          [%give %fact ~[/urb-state] %urb-state !>(new-urb-state)]
+      ==
     ==
   ==
 ::


### PR DESCRIPTION
Previously %urb-watcher would not send state update `%fact`s unless the given range of index blocks had Urb transactions in it. This PR removes that check and sends the new state every time a range of blocks is indexed. This means an active %urb-snapshot agent will upload the snapshot every ~10 minutes in normal operation, which cuts down time-to-boot for any onboarding flow using the snapshot.