### PR TITLE
Fix snapshot response wire

### DIFF
--- a/groundwire/app/urb-snapshot.hoon
+++ b/groundwire/app/urb-snapshot.hoon
@@ -194,7 +194,7 @@
             (trip signature-v2)
           ==
         :_  this
-        :~  :*  %pass  /upload/(scot %uv (cut 5 [0 1] jammed))
+        :~  :*  %pass  /upload/(scot %uv (sham urb-state))
                 %arvo  %i
                 %request
                 :_  *outbound-config:iris


### PR DESCRIPTION
Fixes the hash on %urb-snapshot's `/upload/...` wire such that it is, as originally intended, a short hash of the content of the urb-state noun. This unique ID of the content will help with `+verb` debugging.