### PR TITLE
Fix snapshotting on each block

### DIFF
--- a/groundwire/app/urb-watcher.hoon
+++ b/groundwire/app/urb-watcher.hoon
@@ -224,8 +224,12 @@
         ~
       %+  welp
         (jael-update filtered-udiffs)
-      :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
-          [%give %fact ~[/urb-state] %urb-state !>(new-urb-state)]
+      %+  welp
+        :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
+        ==
+      ?:  =(num.block-id.new-urb-state num.block-id.urb-state.state)
+        ~
+      :~  [%give %fact ~[/urb-state] %urb-state !>(new-urb-state)]
       ==
     ==
   ==


### PR DESCRIPTION
Addendum to https://github.com/gwbtc/groundwire/pull/102 which uploaded a snapshot every time the `/blocks` wire fired. This uploads a new snapshot every time the block height updates.