### PR TITLE
Get the snapshot directly from our server

### DIFF
--- a/onboarding/booting/gw-onboard.py
+++ b/onboarding/booting/gw-onboard.py
@@ -97,7 +97,7 @@ SPONSOR_URL = "http://143.198.70.9:8080"
 SPONSOR_SHIP = "~daplyd"  # star — comet mines under this
 ESCAPE_SPONSOR = "~watwyd-bannyt-parmep-sivpes--motweb-dovfet-nilrec-daplyd"  # networking sponsor for escape
 BLOCK_CONFIRMATIONS = 2
-DEFAULT_SNAPSHOT_URL = "https://groundwire.nyc3.cdn.digitaloceanspaces.com/snapshot/urb-snapshot.jam"
+DEFAULT_SNAPSHOT_URL = "https://groundwire.nyc3.digitaloceanspaces.com/snapshot/urb-snapshot.jam"
 
 from pynoun import noun as pynoun
 


### PR DESCRIPTION
When I run the onboarding process it's usually a few blocks behind the latest one, which slows down onboarding significantly. I suspect this is because the latest snapshot isn't propagated around the CDN by the time I ask for it.

This PR fetches the snapshot directly from our DO droplet and not the CDN. If the snapshot was very large it would be worth using the CDN, but right now it's very small and the download time is nothing compared to the time it takes to catch up to the latest block.