### PR TITLE
urb-snapshot: fix marks

### DIFF
--- a/groundwire/mar/set-config.hoon
+++ b/groundwire/mar/set-config.hoon
@@ -4,8 +4,8 @@
   ++  noun  [url=(unit @t) bucket=(unit @t) region=(unit @t)]
   --
 ++  grow
-  |=  =update
-  ^-  vase
-  !>(update)
+  |%
+  ++  noun  update
+  --
 ++  grad  %noun
 --

--- a/groundwire/mar/set-credentials.hoon
+++ b/groundwire/mar/set-credentials.hoon
@@ -4,8 +4,8 @@
   ++  noun  [url=(unit @t) access-key=(unit @t) secret-key=(unit @t)]
   --
 ++  grow
-  |=  =update
-  ^-  vase
-  !>(update)
+  |%
+  ++  noun  update
+  --
 ++  grad  %noun
 --


### PR DESCRIPTION
Fixes bad marks that would silently fail to build in some cases, loudly now that Clay builds all marks eagerly.