### PR TITLE
groundwire: add missing %txt mark to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ VENDOR_BASE_DEV_GW := \
 	mar/jam.hoon \
 	mar/mime.hoon \
 	mar/hoon.hoon \
+	mar/txt.hoon \
 	sur/asn1.hoon \
 	sur/spider.hoon \
 	sur/verb.hoon


### PR DESCRIPTION
Add %txt mark for groundwire desk from vendored base desk to makefile to prevent crash on boot in CI & Linux.