### PR TITLE
Configure AGENTS.md to pier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(ONBOARD_VENV):
 	python3 -m venv $(ONBOARD_VENV)
 	$(ONBOARD_VENV)/bin/pip install -q -r $(ONBOARD_DIR)/requirements.txt pyinstaller
 
-$(ONBOARD_BIN): $(ONBOARD_VENV) $(ONBOARD_DIR)/gw-onboard.py
+$(ONBOARD_BIN): $(ONBOARD_VENV) $(ONBOARD_DIR)/gw-onboard.py $(ONBOARD_DIR)/AGENTS.md
 	@echo "Building gw-onboard binary..."
 	cd $(ONBOARD_DIR) && .venv/bin/pyinstaller --onefile \
 		--hidden-import requests \
@@ -113,6 +113,7 @@ $(ONBOARD_BIN): $(ONBOARD_VENV) $(ONBOARD_DIR)/gw-onboard.py
 		--hidden-import bitarray._util \
 		--hidden-import nacl._sodium \
 		--hidden-import mmh3 \
+		--add-data AGENTS.md:. \
 		gw-onboard.py
 	@echo "gw-onboard binary built at $(ONBOARD_BIN)"
 

--- a/onboarding/booting/AGENTS.md
+++ b/onboarding/booting/AGENTS.md
@@ -1,0 +1,24 @@
+# Groundwire Agent Instructions
+
+## Identity
+
+You are ${COMET_NAME}, a helpful AI agent instantiated in an Urbit comet running Groundwire software. ${GROUNDWIRE_ID_STATUS}
+
+## Capabilities
+
+Urbit is a P2P network of personal servers built on Nock, each one a pure function of its event log. Groundwire ID is a general-purpose, sybil-resistant DID for humans and agents built on Bitcoin. Your Urbit "comet" is a non-sybil-resistant, self-attested, 128-bit identity to which your Groundwire ID resolves. Groundwire's Urb protocol has affordances for attesting onchain to IP addresses and sponsorship routes from other Urbit nodes running Groundwire, which enables P2P networking across NAT boundaries with minimal centralization and bootstrapping.
+
+The Urbit comet has a built-in MCP server, which has been configured for you as `"${COMET_SHORTNAME}"`. Tools enable read-write access to the ship's Arvo (Urbit OS) and Gall agents (userspace applications). Resources and Resource Templates enable read-only access to Arvo and Gall agents, including third-party applications which might install their own MCP Tools, Resources, and Resource Templates. The ship's MCP server is itself a Gall agent called `%mcp-server` in the `%mcp` desk.
+
+You also have access to the Urbit Docs' GitBook MCP server, which will help you troubleshoot user issues and solve problems working with Hoon and Gall.
+
+## Best Practices for Urbit Development
+
+The above capabilities make this an ideal environment for doing AI-assisted Urbit development. In this context, follow these best practices:
+- Make your changes in the local git repo containing the source code for a desk, not the desk itself. You'll have to make your changes, copy the code to the desk (either with `cp` or, ideally, a script in the root of the repo), then use the `mcp/commit-desk` tool to attempt to commit the changes to Urbit's Clay filesystem. If the source repo has an `AGENTS.md` file or equivalent, consult that too.
+- If you hit a `%load-failed` error on commit, nuke the agent and revive its desk using your MCP tools.
+- A Gall agent has ten arms, such as `+on-poke`. You cannot add more without causing a type error. If you need to add more functionality, put it in a helper core composed into the agent's subject with Hoon's `=>` or `=<` runes or in a library.
+- Hoon's unsigned integers (`@ud`) MUST be separated by a `.` every three digits. If in doubt, consult the docs.
+- Do not put tall-form Hoon in wide-form Hoon expressions. You may put wide-form Hoon in tall-form Hoon. (Use tall-form by default.)
+- Do not add a named expression to the subject using `=/` as if initializing a variable if you're only going to reference that "variable" once. Creating a new subject is expensive!
+- Do not add a state migration (e.g. from `$state-0` to `$state-1`) in an agent unless this is a production app. If in doubt, err on the side of not doing so. We can always add one later. State migrations must explicitly migrate from one state version to the next, e.g. `+state-0-to-1`, and must be applied in sequence in `+on-load`.

--- a/onboarding/booting/gw-onboard.py
+++ b/onboarding/booting/gw-onboard.py
@@ -17,6 +17,7 @@ import secrets
 import signal
 import shutil
 import socket
+import string
 import subprocess
 import sys
 import threading
@@ -1674,18 +1675,92 @@ def get_ship_cookie_from_code(url: str, login_code: str) -> str:
     return _get_ship_cookie_from_login(url, login_code)
 
 
-def _write_ship_mcp_configs(pier_name: str, port: int, ship_cookie: str) -> None:
+def _resource_path(name: str) -> str:
+    """Return a bundled resource path for dev and PyInstaller builds."""
+
+    base_dir = getattr(sys, "_MEIPASS", os.path.dirname(os.path.realpath(__file__)))
+    return os.path.join(base_dir, name)
+
+
+def _mcp_server_name_for_pier(pier_name: str) -> str:
+    """Return a short local MCP server name for an Urbit pier."""
+
+    pier_words = [word for word in re.split(r"-+", pier_name) if word]
+    if len(pier_words) > 4:
+        return f"{pier_words[0]}_{pier_words[-1]}"
+    return pier_name
+
+
+def _render_agent_instructions(
+    comet_name: str,
+    mcp_server_name: str,
+    attested_to_bitcoin: bool,
+) -> str:
+    """Render the pier's agent instruction file from the bundled template."""
+
+    if attested_to_bitcoin:
+        groundwire_id_status = (
+            "You have a permanent, sybil-resistant Groundwire ID attested to on the Bitcoin mainnet."
+        )
+    else:
+        groundwire_id_status = (
+            "You do not have a permanent, sybil-resistant Groundwire ID attested to on the Bitcoin mainnet."
+        )
+
+    with open(_resource_path("AGENTS.md"), encoding="utf-8") as f:
+        template = string.Template(f.read())
+
+    return template.safe_substitute(
+        COMET_NAME=comet_name,
+        COMET_SHORTNAME=mcp_server_name,
+        GROUNDWIRE_ID_STATUS=groundwire_id_status,
+    )
+
+
+def _write_agent_instruction_files(
+    pier_dir: str,
+    comet_name: str,
+    mcp_server_name: str,
+    attested_to_bitcoin: bool,
+) -> None:
+    """Create shared agent instruction files in a pier."""
+
+    agents_path = os.path.join(pier_dir, "AGENTS.md")
+    claude_path = os.path.join(pier_dir, "CLAUDE.md")
+
+    if not os.path.exists(agents_path):
+        with open(agents_path, "w", encoding="utf-8") as f:
+            f.write(_render_agent_instructions(comet_name, mcp_server_name, attested_to_bitcoin))
+
+    if os.path.islink(claude_path) and os.readlink(claude_path) == "AGENTS.md":
+        return
+
+    if os.path.islink(claude_path):
+        os.unlink(claude_path)
+
+    if not os.path.exists(claude_path):
+        os.symlink("AGENTS.md", claude_path)
+
+
+def _write_ship_mcp_configs(
+    pier_name: str,
+    port: int,
+    ship_cookie: str,
+    comet_name: str,
+    attested_to_bitcoin: bool,
+) -> None:
     """Write project-scoped MCP configs for local agent CLIs."""
 
     url = f"http://localhost:{port}/mcp"
     header_cookie = {"Cookie": ship_cookie}
     pier_dir = os.path.abspath(pier_name)
-    pier_words = [word for word in re.split(r"-+", pier_name) if word]
-
-    if len(pier_words) > 4:
-        mcp_server_name = f"{pier_words[0]}_{pier_words[-1]}"
-    else:
-        mcp_server_name = pier_name
+    mcp_server_name = _mcp_server_name_for_pier(pier_name)
+    _write_agent_instruction_files(
+        pier_dir,
+        comet_name,
+        mcp_server_name,
+        attested_to_bitcoin,
+    )
 
     codex_dir = os.path.join(pier_dir, ".codex")
     os.makedirs(codex_dir, exist_ok=True)
@@ -1922,6 +1997,7 @@ def boot_comet(
     vere_bin: str,
     pill: str = GW_PILL,
     snapshot_file: bytes | None = None,
+    attested_to_bitcoin: bool = False,
 ) -> tuple[str, bool, bool, bool, bool, bool]:
     """Boot a comet, wait until idle, kill the process, then return the local URL and installed desks.
 
@@ -2097,7 +2173,13 @@ def boot_comet(
 
     try:
         ship_cookie = get_ship_cookie_from_code(url, login_code)
-        _write_ship_mcp_configs(pier_name, port, ship_cookie)
+        _write_ship_mcp_configs(
+            pier_name,
+            port,
+            ship_cookie,
+            comet_name,
+            attested_to_bitcoin,
+        )
     except Exception as e:
         print(f"ERROR: Failed to generate local MCP config files: {e}")
         proc.kill()
@@ -2359,6 +2441,7 @@ def main():
                 args.vere,
                 pill=args.pill,
                 snapshot_file=snapshot_file,
+                attested_to_bitcoin=False,
             )
             print_boot_success(
                 url,
@@ -2474,6 +2557,7 @@ def main():
             args.vere,
             pill=args.pill,
             snapshot_file=snapshot_file,
+            attested_to_bitcoin=True,
         )
         print_boot_success(
             url,

--- a/onboarding/booting/gw-onboard.spec
+++ b/onboarding/booting/gw-onboard.spec
@@ -5,7 +5,7 @@ a = Analysis(
     ['gw-onboard.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[('AGENTS.md', '.')],
     hiddenimports=['requests', 'nacl.bindings', 'embit.util.secp256k1', '_cffi_backend', 'bitstring.bitstore_bitarray', 'bitstring.bitstore_bitarray_helpers', 'bitstring.bitstore_common_helpers', 'bitstring.bitstore_tibs', 'bitstring.bitstore_tibs_helpers', 'bitarray', 'bitarray._bitarray', 'bitarray._util', 'nacl._sodium', 'mmh3'],
     hookspath=[],
     hooksconfig={},

--- a/onboarding/booting/test_gw_onboard.py
+++ b/onboarding/booting/test_gw_onboard.py
@@ -1,7 +1,9 @@
 """Tests for gw-onboard.py pure functions."""
 
 import importlib.util
+import os
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -241,6 +243,79 @@ class TestCopyToClipboard(unittest.TestCase):
             patch("subprocess.run", side_effect=subprocess.SubprocessError),
         ):
             self.assertFalse(gw.copy_to_clipboard("hello"))
+
+
+class TestAgentInstructionFiles(unittest.TestCase):
+    def test_creates_agents_stub_and_claude_symlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            gw._write_agent_instruction_files(
+                tmp, "~sample-pier", "sample-pier", attested_to_bitcoin=False
+            )
+
+            agents_path = os.path.join(tmp, "AGENTS.md")
+            claude_path = os.path.join(tmp, "CLAUDE.md")
+            self.assertTrue(os.path.isfile(agents_path))
+            with open(agents_path, encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("You are ~sample-pier", content)
+            self.assertIn("configured for you as sample-pier", content)
+            self.assertIn(
+                "You do not have a permanent, sybil-resistant Groundwire ID attested to on the Bitcoin mainnet.",
+                content,
+            )
+            self.assertTrue(os.path.islink(claude_path))
+            self.assertEqual(os.readlink(claude_path), "AGENTS.md")
+
+    def test_preserves_existing_agents_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agents_path = os.path.join(tmp, "AGENTS.md")
+            with open(agents_path, "w", encoding="utf-8") as f:
+                f.write("custom instructions\n")
+
+            gw._write_agent_instruction_files(
+                tmp, "~sample-pier", "sample-pier", attested_to_bitcoin=True
+            )
+
+            with open(agents_path, encoding="utf-8") as f:
+                self.assertEqual(f.read(), "custom instructions\n")
+
+    def test_renders_attested_groundwire_id_status(self):
+        content = gw._render_agent_instructions(
+            "~sample-pier", "sample-pier", attested_to_bitcoin=True
+        )
+
+        self.assertIn(
+            "You have a permanent, sybil-resistant Groundwire ID attested to on the Bitcoin mainnet.",
+            content,
+        )
+        self.assertNotIn("may or may not", content)
+
+    def test_mcp_server_name_for_long_pier(self):
+        self.assertEqual(
+            gw._mcp_server_name_for_pier("watwyd-bannyt-parmep-sivpes-motweb-daplyd"),
+            "watwyd_daplyd",
+        )
+
+    def test_write_ship_mcp_configs_creates_agent_instruction_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pier_path = os.path.join(tmp, "sample-pier")
+            os.mkdir(pier_path)
+
+            gw._write_ship_mcp_configs(
+                pier_path, 8080, "urbauth-test=abc", "~sample-pier", attested_to_bitcoin=True
+            )
+
+            agents_path = os.path.join(pier_path, "AGENTS.md")
+            self.assertTrue(os.path.isfile(agents_path))
+            with open(agents_path, encoding="utf-8") as f:
+                self.assertIn(
+                    "You have a permanent, sybil-resistant Groundwire ID attested to on the Bitcoin mainnet.",
+                    f.read(),
+                )
+            claude_path = os.path.join(pier_path, "CLAUDE.md")
+            self.assertTrue(os.path.islink(claude_path))
+            self.assertEqual(os.readlink(claude_path), "AGENTS.md")
+            self.assertTrue(os.path.isfile(os.path.join(pier_path, ".mcp.json")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Configures an `AGENTS.md` and symlink `CLAUDE.md` to the pier folder as part of `gw-onboard`, such that starting the agent in the pier as recommended gets you an agent that has some context round the tools available to it. Also includes minimal best practices for Hoon development.

A more detailed rundown of the MCP Resources and Templates available is best provided in a hook, which is out-of-scope for this PR.