### PR TITLE
groundwire: rename %groundwire → %gw-btc; real §7 confidential verifier

### DIFF
--- a/groundwire/app/gw-btc.hoon
+++ b/groundwire/app/gw-btc.hoon
@@ -106,7 +106,7 @@
       ::  validates -- so a stale indexed key must NOT hard-fail the writ).
       =/  ind=(unit point:jael)
         ?~  pt=(~(get by unv-ids.urb-state) who.poke)  ~
-        (verify-indexed [dom who pass]:poke u.pt)
+        (verify-indexed dom.poke who.poke pass.poke u.pt)
       ?^  ind
         :_  this
         :~  :*  %give  %fact  ~[/writs]
@@ -121,7 +121,7 @@
       :_  this
       :~  :*  %pass  /writ/(scot %tas dom.poke)/(scot %p who.poke)  %arvo  %k
               %lard  q.byk.bowl
-              (writ-shed [dom who pass]:poke rpc)
+              (writ-shed dom.poke who.poke pass.poke rpc)
           ==
       ==
     ::
@@ -594,7 +594,7 @@
 ::
 ::  +writ-shed: run lib/gw-verify's full section-7 custody walk in a khan
 ::  thread (the confidential / unindexed path), producing its verdict as a
-::  vase for the [%writ @ ~] case in +on-arvo.
+::  vase for the [%writ @ @ ~] case in +on-arvo.
 ::
 ++  writ-shed
   |=  [dom=@tas who=ship =pass rpc=req-to:btcio]

--- a/groundwire/app/gw-btc.hoon
+++ b/groundwire/app/gw-btc.hoon
@@ -1,24 +1,32 @@
-::  %groundwire (né %urb-watcher)
+::  %gw-btc (né %urb-watcher, né %groundwire)
 ::
 ::  This agent is the Groundwire equivalent of %azimuth and %eth-watcher.
 ::  It fetches Bitcoin blocks on a timer and parses them for Jael events.
 ::  Its helper core at the bottom works in conjunction with lib/urb-core.
 ::
-::  It is also the verifier agent for the %groundwire PKI domain in the
+::  It is also the verifier agent for the %gw-btc PKI domain in the
 ::  confidential-comets kernel protocol (see the companion spec
 ::  doc/confidential-comets-agent.md and, in gwbtc/urbit,
 ::  pkg/arvo/doc/spec/confidential-comets.md).  On boot it registers
 ::  itself with Jael via a %anex task, so that when a confidential
 ::  (suite-%c) comet self-attests to us, Ames routes the attestation
-::  here as a %jael-writ poke.  We verify it against our own indexed
-::  view of the chain and answer with a %writ-response fact; on success
-::  Jael stores the point and promotes the comet.  A %jael-anew poke
-::  (our own comet asking for a fresh attestation) is answered with an
-::  %anew-response fact carrying the re-encoded pass.
+::  here as a %jael-writ poke.  We answer with a %writ-response fact; on
+::  success Jael stores the point and promotes the comet.  Two verify
+::  paths:
+::    - INDEXED (fast, synchronous): the comet did an on-chain reveal our
+::      block-watcher already parsed into unv-ids -- consult that point.
+::    - CONFIDENTIAL (async khan thread): the comet is unknown to our
+::      index, so run lib/gw-verify's full section-7 custody walk against
+::      our bitcoin node, answering with the fact when the thread returns.
+::  A %jael-anew poke (our own comet asking for a fresh attestation) is
+::  answered with an %anew-response fact carrying the re-encoded pass.
 ::
 ::  The domain name is this agent's name (1:1 by construction): a comet
-::  commits the tag %groundwire in its key tweak, and Jael derives the
-::  same tag from the gall duct our %anex arrives on.
+::  commits the tag %gw-btc in its key tweak, and Jael derives the same
+::  tag from the gall duct our %anex arrives on.  Because the tag is
+::  hashed into every comet's signing key (and thus its @p), it names the
+::  Groundwire Bitcoin PKI DOMAIN, not this implementation -- do not
+::  rename it to track code changes.
 ::
 ::  Change new-rpc and start-height in ++init to change the network.
 ::  If you're using this in conjunction with the SPV wallet, that
@@ -30,6 +38,7 @@
 ::
 /-  bitcoin, spider, ord, urb
 /+  bc=bitcoin, btcio, dbug, default-agent, uc=urb-core, strandio, verb
+/+  gwv=gw-verify
 ::
 |%
 +$  card  card:agent:gall
@@ -95,10 +104,23 @@
     =/  poke  !<(jael-poke:urb vase)
     ?-    -.poke
         %jael-writ
-      =/  res=(unit point:jael)  (verify-writ [dom who pass]:poke)
+      ::  INDEXED fast path: if our block-watcher already parsed this comet's
+      ::  on-chain reveal into unv-ids, verify against that point synchronously.
+      ?^  pt=(~(get by unv-ids.urb-state) who.poke)
+        =/  res=(unit point:jael)  (verify-indexed [dom who pass]:poke u.pt)
+        :_  this
+        :~  :*  %give  %fact  ~[/writs]
+                %writ-response  !>(`writ-response:jael`[dom.poke who.poke res])
+            ==
+        ==
+      ::  CONFIDENTIAL path: the comet is unknown to our index, so run
+      ::  lib/gw-verify's full section-7 custody walk in a khan thread; its
+      ::  %writ-response fact is emitted when the thread returns (see the
+      ::  [%writ @ ~] case in +on-arvo).
       :_  this
-      :~  :*  %give  %fact  ~[/writs]
-              %writ-response  !>(`writ-response:jael`[dom.poke who.poke res])
+      :~  :*  %pass  /writ/(scot %p who.poke)  %arvo  %k
+              %lard  q.byk.bowl
+              (writ-shed [dom who pass]:poke rpc)
           ==
       ==
     ::
@@ -119,14 +141,14 @@
       %urb-start-indexing
     =/  start-urb  ;;((unit state:urb) !<((unit noun) vase))
     ?~  start-urb
-      %-  (slog :_(~ [%leaf "%urb-watcher: indexing from block {<num.block-id:(state:urb default-urb-state)>}"]))
+      %-  (slog :_(~ [%leaf "%gw-btc: indexing from block {<num.block-id:(state:urb default-urb-state)>}"]))
       :_  this(urb-state default-urb-state)
       :~  :*  %pass  /timer
               %arvo  %b
               %wait  now.bowl
           ==
       ==
-    %-  (slog :_(~ [%leaf "%urb-watcher: processing groundwire snapshot ({<~(wyt by unv-ids.u.start-urb)>} points)"]))
+    %-  (slog :_(~ [%leaf "%gw-btc: processing groundwire snapshot ({<~(wyt by unv-ids.u.start-urb)>} points)"]))
     :_  this(urb-state u.start-urb)
     :~  (listen-to-urb ~(key by unv-ids.u.start-urb) [%| dap.bowl])
         :*  %pass  /timer
@@ -204,6 +226,26 @@
   ^-  (quip card _this)
   ?+    wire  (on-arvo:def wire sign-arvo)
   ::
+  ::  A confidential +writ-shed verify thread returned.  Give the
+  ::  %writ-response fact carrying its verdict (or ~ on failure / crash).
+      [%writ @ ~]
+    ?+    sign-arvo  (on-arvo:def wire sign-arvo)
+        [%khan %arow *]
+      =/  who=ship  (slav %p i.t.wire)
+      =/  res=(unit point:jael)
+        ?.  ?=([%khan %arow %.y %noun *] sign-arvo)
+          ::  thread bailed (rpc failure, unparsable packet): report failure.
+          %-  (slog leaf+"%gw-btc: writ verify thread failed for {<who>}" ~)
+          ~
+        =/  [%khan %arow %.y %noun =vase]  sign-arvo
+        !<((unit point:jael) vase)
+      :_  this
+      :~  :*  %give  %fact  ~[/writs]
+              %writ-response  !>(`writ-response:jael`[dap.bowl who res])
+          ==
+      ==
+    ==
+  ::
   ::  Run +get-blocks at regular intervals.
       [%timer ~]
     :_  this
@@ -222,7 +264,7 @@
         [%khan %arow *]
       ?.  -.p.sign-arvo
         ?>  ?=([%khan %arow %.n *] sign-arvo)
-        %-  (slog leaf+"%urb-watcher: thread failed, retrying" +.p.p.sign-arvo)
+        %-  (slog leaf+"%gw-btc: thread failed, retrying" +.p.p.sign-arvo)
         :_  this
         :~  [%pass /timer %arvo %b %wait (add ~s30 now.bowl)]
         ==
@@ -232,7 +274,7 @@
         !<  
         [(list [id:block:bitcoin effect:urb]) state:urb]
         vase
-      ::  Jael is subscribed to %urb-watcher to receive udiffs for some ships,
+      ::  Jael is subscribed to %gw-btc to receive udiffs for some ships,
       ::  and it isn't subscribed yet for others. For the ones in fx it is, we 
       ::  send udiffs. For the ones it isn't subscribed to yet, we tell it to,
       ::  and it will hit ++on-agent to get the udiff afterwards.
@@ -373,7 +415,7 @@
     ^$(tx-inputs t.tx-inputs)
   ?.  ?=(%spawn -.i.sots)
     $(sots t.sots)
-  ::  ~&  >>  "%urb-watcher found a spawn!"
+  ::  ~&  >>  "%gw-btc found a spawn!"
   ::  If we found an input with a %spawn, get the tx that generated it
   ;<  commit-tx=(unit tx:bc)  bind:m
     (get-raw-transaction:btcio rpc ~ txid.i.tx-inputs)
@@ -390,7 +432,7 @@
   =/  inputs  is.commit-urb-tx
   |-
   ?~  inputs
-    ::  ~&  >>>  "%urb-watcher: Couldn't find precommit tx."
+    ::  ~&  >>>  "%gw-btc: Couldn't find precommit tx."
     ^$(sots t.sots)
   ;<  precommit-tx=(unit tx:bc)  bind:m
     (get-raw-transaction:btcio rpc ~ txid.i.inputs)
@@ -520,11 +562,12 @@
 ::  cards for Jael contain udiffs.
 ::  Confidential-comets verifier arms (see on-poke).
 ::
-::  +verify-writ: verify a comet's self-attestation against our own
-::  indexed chain view, returning the verified Jael point or ~.
+::  +verify-indexed: verify a comet's self-attestation against a point our
+::  block-watcher already parsed from an on-chain reveal, returning the
+::  verified Jael point or ~.  The caller looked the point up in unv-ids.
 ::
-++  verify-writ
-  |=  [dom=@tas who=ship =pass]
+++  verify-indexed
+  |=  [dom=@tas who=ship =pass pt=point:urb]
   ^-  (unit point:jael)
   ::  1. suite-%c pass, carrying the tweak-committed domain at the head
   ::     of its tweak data; it must match the domain Jael routed on
@@ -535,12 +578,27 @@
   ::  2. the name must be the hash of the tweaked key (Ames/Jael
   ::     already checked this; re-derive rather than trust)
   ?.  =(who fig:ex:(com:nu:cric:crypto pass))  ~
-  ::  3. consult our indexed view of this comet's on-chain state
-  ?~  pt=(~(get by unv-ids.urb-state) who)  ~
-  ::  4. the attested messaging key must be the one we've indexed as
-  ::     current (the latest committed state)
-  ?.  =(pass pass.net.u.pt)  ~
-  `(urb-point-to-jael u.pt who)
+  ::  3. the attested MESSAGING KEY (cry) must match the one we indexed as
+  ::     current.  Compare cry, not the whole pass: the pass's xtr reveal
+  ::     log grows independently of the key, so a whole-pass compare would
+  ::     spuriously reject a comet whose attestation carries a longer log
+  ::     than the (public) reveal we parsed.  (The signing key that fixes
+  ::     the @p is already pinned by the fig check in step 2.)
+  =/  ind  +<:(com:nu:cric:crypto pass.net.pt)
+  ?.  ?=([%c *] ind)  ~
+  ?.  =(cry.pub.cek cry.pub.ind)  ~
+  `(urb-point-to-jael pt who)
+::
+::  +writ-shed: run lib/gw-verify's full section-7 custody walk in a khan
+::  thread (the confidential / unindexed path), producing its verdict as a
+::  vase for the [%writ @ ~] case in +on-arvo.
+::
+++  writ-shed
+  |=  [dom=@tas who=ship =pass rpc=req-to:btcio]
+  ^-  shed:khan
+  =/  m  (strand:strandio ,vase)
+  ;<  res=(unit point:jael)  bind:m  (verify:gwv dom who pass rpc)
+  (pure:m !>(res))
 ::
 ::  +fresh-pass: our own current pass, for a %jael-anew refresh
 ::

--- a/groundwire/app/gw-btc.hoon
+++ b/groundwire/app/gw-btc.hoon
@@ -87,38 +87,39 @@
   |=  [=mark =vase]
   ^-  (quip card _this)
   ?+    mark  !!
-      ::  Jael forwards a comet self-attestation for on-chain
-      ::  verification.  We verify against our indexed chain view and
-      ::  answer with a %writ-response fact on /writs; on success Jael
-      ::  stores the point and promotes the comet.
-      ::
-      ::    NB: full variant-B verification (fetch each custody-log tx
-      ::    from a txindexed node and walk the sat, spec S7) is not yet
-      ::    wired here; we consult the point our block-watcher already
-      ::    indexed into urb-state, which is the same trust model
-      ::    ("the agent's own view of the chain") and is what the
-      ::    aqua tests exercise.  XX wire the tx-walk for unindexed or
-      ::    newer-than-indexed attestations.
+      ::  Jael forwards a comet self-attestation for on-chain verification
+      ::  (%jael-writ) or asks us to refresh our own (%jael-anew).  Both are
+      ::  local vane->agent pokes ([our our /jael]), so gate on src.
       ::
       %noun
+    ?.  =(our.bowl src.bowl)
+      ~&  >>>  [%gw-btc %foreign-noun-poke src.bowl]
+      `this
     =/  poke  !<(jael-poke:urb vase)
     ?-    -.poke
         %jael-writ
-      ::  INDEXED fast path: if our block-watcher already parsed this comet's
-      ::  on-chain reveal into unv-ids, verify against that point synchronously.
-      ?^  pt=(~(get by unv-ids.urb-state) who.poke)
-        =/  res=(unit point:jael)  (verify-indexed [dom who pass]:poke u.pt)
+      ::  INDEXED fast path: only a SUCCESSFUL indexed verify short-circuits.
+      ::  If our block-watcher parsed this comet's on-chain reveal into
+      ::  unv-ids and it still validates, answer synchronously; otherwise
+      ::  fall through to the confidential walk (an indexed comet may have
+      ::  rotated its key off-chain via a %state commitment the walk
+      ::  validates -- so a stale indexed key must NOT hard-fail the writ).
+      =/  ind=(unit point:jael)
+        ?~  pt=(~(get by unv-ids.urb-state) who.poke)  ~
+        (verify-indexed [dom who pass]:poke u.pt)
+      ?^  ind
         :_  this
         :~  :*  %give  %fact  ~[/writs]
-                %writ-response  !>(`writ-response:jael`[dom.poke who.poke res])
+                %writ-response  !>(`writ-response:jael`[dom.poke who.poke ind])
             ==
         ==
-      ::  CONFIDENTIAL path: the comet is unknown to our index, so run
-      ::  lib/gw-verify's full section-7 custody walk in a khan thread; its
-      ::  %writ-response fact is emitted when the thread returns (see the
-      ::  [%writ @ ~] case in +on-arvo).
+      ::  CONFIDENTIAL path (unindexed, or indexed-but-unverified): run
+      ::  lib/gw-verify's full section-7 custody walk in a khan thread; the
+      ::  %writ-response fact is emitted when it returns (the [%writ @ @ ~]
+      ::  case in +on-arvo).  dom + who ride the wire so the response is
+      ::  answered under the routed domain, not just our name.
       :_  this
-      :~  :*  %pass  /writ/(scot %p who.poke)  %arvo  %k
+      :~  :*  %pass  /writ/(scot %tas dom.poke)/(scot %p who.poke)  %arvo  %k
               %lard  q.byk.bowl
               (writ-shed [dom who pass]:poke rpc)
           ==
@@ -228,10 +229,12 @@
   ::
   ::  A confidential +writ-shed verify thread returned.  Give the
   ::  %writ-response fact carrying its verdict (or ~ on failure / crash).
-      [%writ @ ~]
+  ::  dom + who ride the wire (/writ/<dom>/<who>).
+      [%writ @ @ ~]
     ?+    sign-arvo  (on-arvo:def wire sign-arvo)
         [%khan %arow *]
-      =/  who=ship  (slav %p i.t.wire)
+      =/  dom=@tas  (slav %tas i.t.wire)
+      =/  who=ship  (slav %p i.t.t.wire)
       =/  res=(unit point:jael)
         ?.  ?=([%khan %arow %.y %noun *] sign-arvo)
           ::  thread bailed (rpc failure, unparsable packet): report failure.
@@ -241,7 +244,7 @@
         !<((unit point:jael) vase)
       :_  this
       :~  :*  %give  %fact  ~[/writs]
-              %writ-response  !>(`writ-response:jael`[dap.bowl who res])
+              %writ-response  !>(`writ-response:jael`[dom who res])
           ==
       ==
     ==

--- a/groundwire/app/reg-tester.hoon
+++ b/groundwire/app/reg-tester.hoon
@@ -41,7 +41,7 @@
                 %arvo
                 %k
                 %fard
-                :*  %groundwire
+                :*  %gw-btc
                     %btc-spawn
                     [%noun !>(`[rpc sed i.bat.many])]
                 ==
@@ -56,7 +56,7 @@
               %arvo
               %k
               %fard
-              :*  %groundwire
+              :*  %gw-btc
                   `term`(rap 3 ~[%btc- (head i.bat.many)])
                   [%noun !>(`[rpc sed utxo i.bat.many])]
               ==
@@ -70,7 +70,7 @@
               %arvo
               %k
               %fard
-              [%groundwire %btc-spawn [%noun !>(`[rpc sed many])]]
+              [%gw-btc %btc-spawn [%noun !>(`[rpc sed many])]]
           ==
       ==
     ::
@@ -81,7 +81,7 @@
               %arvo
               %k
               %fard
-              :*  %groundwire
+              :*  %gw-btc
                   `term`(rap 3 ~[%btc- -.many])
                   [%noun !>(`[rpc sed utxo many])]
               ==
@@ -140,11 +140,11 @@
               %k
               %fard
               ?:  =(%spawn -.i.new-batch)
-                :*  %groundwire
+                :*  %gw-btc
                     %btc-spawn
                     [%noun !>(`[rpc sed.pole i.new-batch])]
                 ==
-              :*  %groundwire
+              :*  %gw-btc
                   `term`(rap 3 ~[%btc- (head i.new-batch)])
                   [%noun !>(`[rpc `@uw`(slav %uw sed.pole) utxo i.new-batch])]
               ==

--- a/groundwire/app/urb-snapshot.hoon
+++ b/groundwire/app/urb-snapshot.hoon
@@ -37,8 +37,8 @@
 ++  on-init
   ^-  (quip card _this)
   :_  this
-  :~  :*  %pass   /groundwire/update/urb-state
-          %agent  [our.bowl %groundwire]
+  :~  :*  %pass   /gw-btc/update/urb-state
+          %agent  [our.bowl %gw-btc]
           %watch  /urb-state
       ==
   ==
@@ -105,7 +105,7 @@
   |=  [=(pole knot) =sign:agent:gall]
   ^-  (quip card _this)
   ?+    pole  (on-agent:def pole sign)
-      [%groundwire %update %urb-state ~]
+      [%gw-btc %update %urb-state ~]
     ?+    -.sign  (on-agent:def pole sign)
         %fact
       ?+    p.cage.sign  (on-agent:def pole sign)

--- a/groundwire/desk.bill
+++ b/groundwire/desk.bill
@@ -1,4 +1,4 @@
 :~  %reg-tester
-    %groundwire
+    %gw-btc
     %urb-snapshot
 ==

--- a/groundwire/doc/confidential-comets-agent.md
+++ b/groundwire/doc/confidential-comets-agent.md
@@ -1,6 +1,6 @@
-# %groundwire: the confidential-comets verifier agent
+# %gw-btc: the confidential-comets verifier agent
 
-Status: **draft** (branch `cyc/groundwire-agent`)
+Status: **draft** (branch `cyc/groundwire-agent` (this agent's base branch))
 
 Companion to the kernel-side spec in **gwbtc/urbit**,
 `pkg/arvo/doc/spec/confidential-comets.md` (branches `cyc/cc-draft` /
@@ -11,12 +11,12 @@ the protocol and assumes the kernel task/gift API it defines.
 
 The kernel treats on-chain identity verification as a pluggable **PKI
 domain**: a local Gall agent, registered with Jael, owns all chain
-knowledge for one domain. `%groundwire` (renamed from `%urb-watcher`)
-is that agent for the `%groundwire` domain on Bitcoin.
+knowledge for one domain. `%gw-btc` (renamed from `%urb-watcher`, then `%groundwire`)
+is that agent for the `%gw-btc` domain on Bitcoin.
 
 Domain and agent are **1:1 by construction** (kernel spec §2.2): the
 domain name *is* this agent's name. A confidential comet commits the
-tag `%groundwire` in its key tweak; Jael derives the same tag from the
+tag `%gw-btc` in its key tweak; Jael derives the same tag from the
 gall duct our `%anex` arrives on. Neither side names the other
 directly — they meet at the shared tag.
 
@@ -36,12 +36,12 @@ three responsibilities:
 confidential comet ~zig          our ship
   |  suite-%c self-attestation      |
   |  (pass tweak commits            |
-  |   %groundwire + spawn-satpoint) |
+  |   %gw-btc + spawn-satpoint) |
   |-------------------------------->|  ames +on-hear-open / +al-take-proof
   |                                 |    unknown / newer life?
-  |                                 |--%writ %groundwire ~zig pass--> jael
-  |                                 |         |  dos lookup: %groundwire
-  |                                 |         |--%jael-writ poke--> %groundwire
+  |                                 |--%writ %gw-btc ~zig pass--> jael
+  |                                 |         |  dos lookup: %gw-btc
+  |                                 |         |--%jael-writ poke--> %gw-btc
   |                                 |         |                       (this agent)
   |                                 |         |<--%writ-response fact--  verify
   |                                 |         |  store point; %public-keys
@@ -60,7 +60,7 @@ three fact marks on that path, and Jael routes on the mark:
 
 ## 3. Verification (`+verify-writ`)
 
-`%jael-writ` carries `[dom=%groundwire who=@p pass]`. We:
+`%jael-writ` carries `[dom=%gw-btc who=@p pass]`. We:
 
 1. Decode the pass; assert suite `%c`; extract the tweak-committed
    domain (`+rub` over the head of `dat.tw.pub`) and confirm it equals
@@ -110,13 +110,13 @@ agent, so comets are already `%known` before any packet — the
 (branch `cyc/groundwire-aqua`, and the companion tests added to
 gwbtc/urbit's harness) instead:
 
-- boots a suite-`%c` comet whose tweak commits `%groundwire` + a
+- boots a suite-`%c` comet whose tweak commits `%gw-btc` + a
   spawn satpoint,
-- registers a `%groundwire` verifier agent on the *receiving* ship and
+- registers a `%gw-btc` verifier agent on the *receiving* ship and
   seeds its `unv-ids` with the attesting comet's point (simulating a
   prior block-index), **without** telling Jael,
 - lets the comet self-attest, so the receiver's Ames sees an unknown
-  suite-`%c` comet and drives the real `%writ` → `%groundwire` →
+  suite-`%c` comet and drives the real `%writ` → `%gw-btc` →
   `%writ-response` → `%sybl` → promotion loop,
 - asserts promotion (Jael now holds the point; a `|hi` succeeds), and
   the `%fail` path (a corrupt/mismatched attestation is snubbed).
@@ -132,3 +132,65 @@ See that branch's report for results.
   kernel spec's `%anew` dual.
 - Decide the watch-path story if a ship hosts more than one PKI domain
   agent (kernel currently tracks one domain per desk via `%tire`).
+
+## Confidential (unindexed) verification — the section-7 custody walk
+
+The agent answers a `%jael-writ` on one of two paths:
+
+- **Indexed (fast, synchronous).** The comet did an *on-chain* reveal our
+  block-watcher already parsed into `unv-ids`. `+verify-indexed` checks the
+  attestation against that point: suite-%c, domain tag matches, `@p` = `fig`
+  of the tweaked key, and the pass's **messaging key `cry`** equals the
+  indexed one. (We compare `cry`, not the whole pass, because the pass's
+  `xtr` reveal log grows independently of the key; a whole-pass compare
+  spuriously rejects a longer log.)
+
+- **Confidential (async).** The comet is unknown to our index, so its reveal
+  never hit the chain. `app/gw-btc` spawns a khan thread running
+  `lib/gw-verify`'s full **section-7 custody walk** and emits the
+  `%writ-response` fact when it returns. This replaces the `XX`-stubbed
+  variant-B walk the agent previously shipped with.
+
+`lib/gw-verify` (`+verify` strand → pure `+walk-checks`):
+
+1. Decode the suite-%c pass into `cry` (messaging key), `dat` (immutable
+   tweak: `+mat`-encoded domain tag + spawn satpoint) and `xtr` (the
+   off-chain **custody log**). Assert the domain tag matches and re-derive
+   `who = fig(tweaked key)`.
+2. Walk the custody log spawn → tip. Each `[txid block-height reveal]` entry
+   names a tx the agent fetches from its own node (height → hash →
+   `getrawtransaction`-in-block, so **no `-txindex` needed**) and re-checks:
+   input-0 key-path-spends the previous sat-carrying output, and the sat
+   tracks deterministically to its landing output (`index-to-sont`).
+   **State commitments** (kernel spec §2.1): only entries carrying a `reveal`
+   re-attest networking state — their landing output's taproot key must equal
+   `Q = P + H_TapTweak(x(P) ‖ leaf-hash) · G` (single-leaf sparse tree, root
+   == leaf-hash) — and only the **latest** such `%state` is authoritative.
+   Bare entries (`reveal=~`) just prove custody moved.
+3. The tip must be unspent (`gettxout`), and the pass's `cry` must equal the
+   latest attested key.
+4. Verdict: `[rift=0 life keys sponsor fief=~]` from the latest state
+   (kernel spec §7).
+
+### On-chain commitment format (`%state`, opcode 9)
+
+Re-attestations commit a **`%state` snapshot** — `[life key sponsor]`,
+where `key` is the messaging `cry` and a sponsor carries a Schnorr
+**consent** signature — in an off-chain-revealed tapleaf (`lib/urb-encoder`,
+`sur/urb` `$gw-state`/`$reveal`/`$xtr-entry`). The `%spawn` single seeds the
+initial state (life 1). This is the shared Causeway↔agent contract; the
+encoders are pinned by `urbit eval` round-trip vectors.
+
+### Deviations / open items flagged for the spec author (cyc)
+
+- **Sponsor-consent signature** is an addition over §7 (which records the
+  sponsor ship but no consent proof); the signature verification hook is
+  present in the encoding but the check itself is a TODO.
+- **txid byte order** in `dat`/`xtr` must match Causeway's encoder and the
+  node's tx ids (flagged `XX` in `+parse-dat-sont`).
+- **entry-0 (spawn) placement** and `%spawn` → initial-state extraction are
+  a reasonable reading of the §7 pseudocode, not a pinned spec.
+- The verifier **cannot be compiled here** (it needs the cc-draft-2 `%base`
+  for `point:jael`); its pure primitives (taproot tweak, `%state` codec,
+  `dat` decode) are `urbit eval`-verified, the rest is written against the
+  spec and needs a fakeship/aqua run.

--- a/groundwire/lib/btcio.hoon
+++ b/groundwire/lib/btcio.hoon
@@ -135,6 +135,52 @@
   ?~  res=(de:base16:mimes:html p.res.res)  (pure:m ~)
   (pure:m `[txid (decodew:txu:bc u.res)])
 ::
+::  +get-raw-transaction-in-block: fetch a tx by txid AND blockhash.  Passing
+::  the blockhash lets a NON-txindexed node find the tx (Core validates that
+::  the txid is in that block; a lying blockhash simply fails the fetch).
+::  Used by lib/gw-verify's custody walk.  (The confidential-comets spec
+::  section 8 assumes a -txindex node and locates by height; this variant
+::  keeps parity with %urb-watcher's own block processing and needs no index.)
+::
+++  get-raw-transaction-in-block
+  |=  [=req-to id=(unit @t) txid=@ux block=@ux]
+  =/  m  (strand:strandio (unit tx:bc))
+  ^-  form:m
+  ;<  res=response:rpc  bind:m
+    %+  request-rpc  req-to
+    ^-  request:rpc
+    :*  ?~(id 'get-raw-transaction-in-block' u.id)
+        '2.0'
+        'getrawtransaction'
+        list+[s+(render-hex-bytes 32 txid) b+| s+(render-hex-bytes 32 block) ~]
+    ==
+  ?.  ?=([%result * [%s *]] res)  (pure:m ~)
+  ?~  res=(de:base16:mimes:html p.res.res)  (pure:m ~)
+  (pure:m `[txid (decodew:txu:bc u.res)])
+::
+::  +get-tx-out: query whether a specific output is unspent (RPC gettxout).
+::
+::    Produces ~ on RPC error, `%.y if the output is unspent (UTXO present),
+::    or `%.n if it is spent or does not exist (gettxout yields JSON null).
+::    gettxout includes the mempool, so a tip spent by an unconfirmed tx reads
+::    as spent (conservative) and an unconfirmed tip reads as live.
+::
+++  get-tx-out
+  |=  [=req-to id=(unit @t) txid=@ux vout=@ud]
+  =/  m  (strand:strandio (unit ?))
+  ^-  form:m
+  ;<  res=response:rpc  bind:m
+    %+  request-rpc  req-to
+    ^-  request:rpc
+    :*  ?~(id 'get-tx-out' u.id)
+        '2.0'
+        'gettxout'
+        list+[s+(render-hex-bytes 32 txid) (numb:enjs:format vout) ~]
+    ==
+  ?.  ?=([%result *] res)  (pure:m ~)
+  ?:  ?=(~ res.res)  (pure:m `%.n)
+  (pure:m `%.y)
+::
 ++  get-block-count
   |=  [=req-to id=(unit @t)]
   =/  m  (strand:strandio (unit @ud))

--- a/groundwire/lib/gw-verify.hoon
+++ b/groundwire/lib/gw-verify.hoon
@@ -159,14 +159,17 @@
 ::  otherwise it is dropped, so a %state can never forge a sponsor.
 ::
 ++  parse-state
-  |=  =reveal:urb
+  |=  [who=ship =reveal:urb]
   ^-  (unit gw-state:urb)
   ?~  parsed=(parse-leaf leaf-script.reveal)  ~
   ?~  st=(find-single %state u.parsed)  ~
   ?>  ?=(%state -.u.st)
+  ::  a claimed sponsor is honored only with verified consent; absent or
+  ::  unverified, fall back to the STRUCTURAL sponsor (never a null sponsor
+  ::  to Jael -- see urb-core / fx-to-udiffs), same default as the spawn.
   =/  spo=(unit @p)
-    ?~  sponsor.u.st  ~
-    ?.  (consent-ok u.sponsor.u.st)  ~
+    ?~  sponsor.u.st  `(^sein:title who)
+    ?.  (consent-ok u.sponsor.u.st)  `(^sein:title who)
     `who.u.sponsor.u.st
   `[life=life.u.st key=key.u.st sponsor=spo]
 ::
@@ -272,7 +275,7 @@
     ?~  reveal.entry  `state
     ?~  onchain=(p2tr-at u.this vout.landed)  ~
     ?.  =(u.onchain (out-key u.reveal.entry))  ~
-    (parse-state u.reveal.entry)
+    (parse-state who u.reveal.entry)
   ?~  new-state  ~
   $(entries t.entries, txs t.txs, sont next, state u.new-state)
 ::

--- a/groundwire/lib/gw-verify.hoon
+++ b/groundwire/lib/gw-verify.hoon
@@ -147,20 +147,40 @@
   ?>  ?=(%spawn -.u.sp)
   =/  cek  +<:(com:nu:cric:crypto pass.u.sp)
   ?.  ?=([%c *] cek)  ~
+  ::  bind the committed pass to who: the spawn leaf's OWN pass must
+  ::  fingerprint to the comet's @p, else an attacker could copy a
+  ::  victim's spawn (same dat + public cry) under a fresh ugn / @p and
+  ::  ride the victim's whole chain (sat-reuse identity forgery).
+  ?.  =(who fig:ex:(com:nu:cric:crypto pass.u.sp))  ~
   `[life=1 key=cry.pub.cek sponsor=`(^sein:title who)]
 ::
-::  +parse-state: the networking state a %state leaf re-attests.
-::  A sponsor+consent, when present, is carried through for signature check.
+::  +parse-state: the networking state a %state leaf re-attests.  A claimed
+::  sponsor is honored ONLY if its consent signature verifies (+consent-ok);
+::  otherwise it is dropped, so a %state can never forge a sponsor.
 ::
 ++  parse-state
   |=  =reveal:urb
-  ^-  (unit [gw-state:urb consent=(unit consent:urb)])
+  ^-  (unit gw-state:urb)
   ?~  parsed=(parse-leaf leaf-script.reveal)  ~
   ?~  st=(find-single %state u.parsed)  ~
   ?>  ?=(%state -.u.st)
-  :-  ~
-  :-  [life=life.u.st key=key.u.st sponsor=?~(sponsor.u.st ~ `who.u.sponsor.u.st)]
-  sponsor.u.st
+  =/  spo=(unit @p)
+    ?~  sponsor.u.st  ~
+    ?.  (consent-ok u.sponsor.u.st)  ~
+    `who.u.sponsor.u.st
+  `[life=life.u.st key=key.u.st sponsor=spo]
+::
+::  +consent-ok: does a sponsor's consent signature authorize adopting this
+::  comet?  XX TODO (a deviation we add over spec §7, which records the
+::  sponsor but no consent proof): verify sig over the consent message
+::  against the sponsor's key + a freshness window, à la urb-core's escape
+::  sig.  Until pinned, conservatively REJECT -- a confidential comet
+::  self-sponsors rather than let an unchecked claim install a sponsor.
+::
+++  consent-ok
+  |=  =consent:urb
+  ^-  ?
+  %.n
 ::
 ::  +parse-dat-sont: recover the spawn satpoint committed in the pass tweak.
 ::  dat = (can 0 (mat dom) [256 txid] (mat vout) (mat off) ~) -- so after the
@@ -187,7 +207,10 @@
 ++  parse-custody-log
   |=  xtr=@
   ^-  (unit custody-log:urb)
-  ?:  =(0 xtr)  `~
+  ::  a confidential comet always carries at least entry-0 (the spawn); an
+  ::  empty xtr is not a verifiable log (fail rather than accept an empty
+  ::  chain).
+  ?:  =(0 xtr)  ~
   %-  mole
   |.  ;;(custody-log:urb (cue xtr))
 ::
@@ -213,6 +236,11 @@
   ?~  tx0=i.fetched  ~
   ?~  rev0=reveal.i.log  ~
   ?.  =(id.u.tx0 txid.spawn-sont)  ~
+  ?.  (lth vout.spawn-sont (lent os.u.tx0))  ~
+  ::  the sat's offset must lie within its home output's value (the bound
+  ::  urb-core's is-sont-in-input enforces on chain; interior links get it
+  ::  for free from index-to-sont, but entry-0's offset comes from dat).
+  ?.  (lth off.spawn-sont value:(snag vout.spawn-sont os.u.tx0))  ~
   ?~  onchain0=(p2tr-at u.tx0 vout.spawn-sont)  ~
   ?.  =(u.onchain0 (out-key u.rev0))  ~
   ?~  state0=(parse-spawn-state who u.rev0)  ~
@@ -244,8 +272,7 @@
     ?~  reveal.entry  `state
     ?~  onchain=(p2tr-at u.this vout.landed)  ~
     ?.  =(u.onchain (out-key u.reveal.entry))  ~
-    ?~  ps=(parse-state u.reveal.entry)  ~
-    `-.u.ps
+    (parse-state u.reveal.entry)
   ?~  new-state  ~
   $(entries t.entries, txs t.txs, sont next, state u.new-state)
 ::
@@ -272,13 +299,14 @@
   |=  [dom=@tas who=ship =pass rpc=req-to:btcio]
   =/  m  (strand:strandio ,(unit point:jael))
   ^-  form:m
-  =/  cek  +<:(com:nu:cric:crypto pass)
+  =/  cac  (com:nu:cric:crypto pass)
+  =/  cek  +<:cac
   ?.  ?=([%c *] cek)  (pure:m ~)
   =/  cry  cry.pub.cek
   ::  domain committed in the tweak must match what Jael routed
   ?.  =(dom `@tas`q:(rub 0 dat.tw.pub.cek))  (pure:m ~)
   ::  name must be the fingerprint of the tweaked key (re-derive, don't trust)
-  ?.  =(who fig:ex:(com:nu:cric:crypto pass))  (pure:m ~)
+  ?.  =(who fig:ex:cac)  (pure:m ~)
   ?~  spawn-sont=(parse-dat-sont dat.tw.pub.cek)  (pure:m ~)
   ?~  log=(parse-custody-log xtr.tw.pub.cek)  (pure:m ~)
   ::  fetch each entry's tx in its attested block (height -> hash -> in-block)

--- a/groundwire/lib/gw-verify.hoon
+++ b/groundwire/lib/gw-verify.hoon
@@ -1,0 +1,313 @@
+::  lib/gw-verify.hoon
+::
+::  Confidential-comets custody-walk verifier (cc-draft-2 kernel spec, section 7:
+::  gwbtc/urbit pkg/arvo/doc/spec/confidential-comets.md).
+::
+::  %gw-btc calls +verify in a khan thread to answer a %jael-writ poke for a
+::  comet that is NOT in its indexed on-chain view -- the confidential /
+::  unindexed path.  (Public comets that did an on-chain reveal are answered
+::  synchronously from unv-ids; see +verify-writ in app/gw-btc.)  This replaces
+::  the "full variant-B tx-fetch custody walk (spec S7) is stubbed (XX)" marker
+::  the agent shipped with.
+::
+::  The section-7 algorithm, given a suite-%c $pass carrying its own attestation:
+::
+::    1. decode the pass: cry (messaging key), dat (immutable tweak: mat-encoded
+::       PKI domain tag + spawn satpoint) and xtr (the OFF-CHAIN reveal of the
+::       on-chain custody log).  Assert the domain tag matches what Jael routed,
+::       and re-derive who = fig(tweaked key) rather than trusting it.
+::    2. walk the custody log spawn -> tip.  It is a LOCATOR, not a proof: each
+::       [txid block-height reveal] entry names a tx the agent fetches from its
+::       own node and re-checks (input-0 key-path-spends the previous
+::       sat-carrying output; the sat tracks deterministically to its landing
+::       output).  Commitments carry full STATES (spec section 2.1), so only
+::       entries with a $reveal re-attest networking state -- their landing
+::       output's taproot key must equal Q recomputed from the disclosed leaf
+::       (single-leaf sparse tree, root == leaf-hash) -- and only the LATEST
+::       such state is authoritative.  Bare entries just prove custody moved.
+::    3. the tip must be unspent on our node, and the pass's current messaging
+::       key must equal the latest attested one.
+::    4. verdict: the point, from the latest committed state (rift 0, fief ~,
+::       per spec section 7).
+::
+::  The strand does the (async) node fetches; +walk-checks is the pure verifier
+::  over the fetched txs, so it is unit-testable without a node.  Ported
+::  primitives (+out-key, +p2tr-xonly, +is-key-path, +parse-leaf) mirror the
+::  hd/urb-handler self-attestation prototype and lib/urb-core's on-chain math.
+::
+::  XX flagged for spec-author (cyc) review -- consensus-critical interpretations
+::  of the section-7 pseudocode; see the marked arms:
+::    - entry-0 (spawn) placement + %spawn->initial-state extraction
+::    - txid byte-order between dat/xtr and the node's tx ids (must match
+::      Causeway's dat/xtr encoder)
+::    - sponsor-consent signature verification (a deviation we add over section 7)
+::
+/-  bitcoin, ord, urb
+/+  bc=bitcoin, bscr=btc-script, btcio, strandio, tr=taproot, ue=urb-encoder, uc=urb-core
+|%
+::  +out-key: reconstruct the taproot output x-only key committed by a $reveal.
+::  The tree is a single leaf, so the merkle root IS that leaf's hash.
+::
+++  out-key
+  |=  =reveal:urb
+  ^-  @ux
+  =/  =tapleaf:tr  [leaf-version.reveal leaf-script.reveal]
+  (output-pubkey:tr internal-key.reveal `(leaf-hash:tr tapleaf))
+::
+::  +p2tr-xonly: extract the 32-byte x-only key from a P2TR scriptPubKey
+::  (OP_1 PUSH32 <key> = 0x51 0x20 ...).  ~ if not a v1 taproot output.
+::
+++  p2tr-xonly
+  |=  spk=hexb:bitcoin
+  ^-  (unit @ux)
+  ?.  =(34 wid.spk)  ~
+  ?.  =(0x5120 (rsh [3 32] dat.spk))  ~
+  `(end [3 32] dat.spk)
+::
+::  +is-key-path: a taproot key-path witness is a single element (the Schnorr
+::  signature, 64 or 65 bytes) with no control block.  XX annex not handled
+::  (a key-path spend with a 0x50-prefixed annex is wrongly rejected -- a false
+::  negative, not a hole).
+::
+++  is-key-path
+  |=  wit=witness:tx:bitcoin
+  ^-  ?
+  ?.  ?=([* ~] wit)  %.n
+  |(=(64 wid.i.wit) =(65 wid.i.wit))
+::
+::  +snag-input: input at index `idx`, or ~ if out of range.
+::
+++  snag-input
+  |=  [idx=@ud =tx:bc]
+  ^-  (unit inputw:tx:bitcoin)
+  ?:  (gte idx (lent is.tx))  ~
+  `(snag idx is.tx)
+::
+::  +p2tr-at: the x-only taproot key of tx's output `vout`, if present + P2TR.
+::
+++  p2tr-at
+  |=  [=tx:bc vout=@ud]
+  ^-  (unit @ux)
+  ?.  (lth vout (lent os.tx))  ~
+  (p2tr-xonly script-pubkey:(snag vout os.tx))
+::
+::  +parse-leaf: decode the sotx(es) committed in a tapleaf script exactly as
+::  urb-core does for on-chain reveals (btc-script -> unv -> raw-sotx).  The
+::  encoder parsers crash on malformed input; a malicious packet must yield a
+::  failed verdict, not a thread crash, so the parse is virtualized.  ~ =
+::  unparsable.
+::
+++  parse-leaf
+  |=  script=hexb:bitcoin
+  ^-  (unit (list raw-sotx:urb))
+  %-  mole
+  |.
+  ^-  (list raw-sotx:urb)
+  =/  oct=octs  [wid.script dat.script]
+  =/  descr  (de:bscr oct)
+  ?~  descr  !!
+  =/  unvs=(list @)  (unv:de:ue u.descr)
+  (zing (turn unvs parse-roll:ue))
+::
+::  +find-single: the first single of the given opcode across a parsed leaf
+::  (expanding %batch), or ~.
+::
+++  find-single
+  |*  [tag=?(%spawn %state) sots=(list raw-sotx:urb)]
+  |^  ^-  (unit single:skim-sotx:urb)
+  |-
+  ?~  sots  ~
+  =/  hit  (scan-one +.sot.i.sots)
+  ?^  hit  hit
+  $(sots t.sots)
+  ++  scan-one
+    |=  act=skim-sotx:urb
+    ^-  (unit single:skim-sotx:urb)
+    ::  a bare single of the sought opcode (the ?= narrows act to a single
+    ::  so it nests in the return type; =tag then picks the exact opcode)
+    ?:  ?&(?=(?(%spawn %state) -.act) =(tag -.act))  `act
+    ?.  ?=(%batch -.act)  ~
+    |-  ^-  (unit single:skim-sotx:urb)
+    ?~  bat.act  ~
+    ?:  =(tag -.i.bat.act)  `i.bat.act
+    $(bat.act t.bat.act)
+  --
+::
+::  +parse-spawn-state: the initial networking state from entry-0's %spawn leaf.
+::  life 1, messaging key = the cry of the spawn pass, sponsor = the comet's
+::  structural sponsor (spec section 7: %spawn -> initial state).
+::  XX interpretation: a comet's on-chain sponsor at spawn is (sein who); a
+::     confidential comet can only change it via a later %state re-attestation.
+::
+++  parse-spawn-state
+  |=  [who=ship =reveal:urb]
+  ^-  (unit gw-state:urb)
+  ?~  parsed=(parse-leaf leaf-script.reveal)  ~
+  ?~  sp=(find-single %spawn u.parsed)  ~
+  ?>  ?=(%spawn -.u.sp)
+  =/  cek  +<:(com:nu:cric:crypto pass.u.sp)
+  ?.  ?=([%c *] cek)  ~
+  `[life=1 key=cry.pub.cek sponsor=`(^sein:title who)]
+::
+::  +parse-state: the networking state a %state leaf re-attests.
+::  A sponsor+consent, when present, is carried through for signature check.
+::
+++  parse-state
+  |=  =reveal:urb
+  ^-  (unit [gw-state:urb consent=(unit consent:urb)])
+  ?~  parsed=(parse-leaf leaf-script.reveal)  ~
+  ?~  st=(find-single %state u.parsed)  ~
+  ?>  ?=(%state -.u.st)
+  :-  ~
+  :-  [life=life.u.st key=key.u.st sponsor=?~(sponsor.u.st ~ `who.u.sponsor.u.st)]
+  sponsor.u.st
+::
+::  +parse-dat-sont: recover the spawn satpoint committed in the pass tweak.
+::  dat = (can 0 (mat dom) [256 txid] (mat vout) (mat off) ~) -- so after the
+::  mat-encoded domain at bit 0 come 256 bits of txid, then mat(vout), mat(off).
+::  XX txid here is Causeway's dat encoding (display-hex as @ux); it must use the
+::     SAME byte order as the node's tx ids the walk compares against.
+::
+++  parse-dat-sont
+  |=  dat=@
+  ^-  (unit sont:ord)
+  %-  mole
+  |.
+  ^-  sont:ord
+  =/  md   (rub 0 dat)
+  =/  cur  p.md
+  =/  txid  (cut 0 [cur 256] dat)  =.  cur  (add cur 256)
+  =/  mv   (rub cur dat)           =.  cur  (add cur p.mv)
+  =/  mo   (rub cur dat)
+  [txid q.mv q.mo]
+::
+::  +parse-custody-log: cue the reveal log out of the pass's untweaked xtr.
+::  Kernel-opaque + attacker-controlled, so virtualized.  ~ = unparsable.
+::
+++  parse-custody-log
+  |=  xtr=@
+  ^-  (unit custody-log:urb)
+  ?:  =(0 xtr)  `~
+  %-  mole
+  |.  ;;(custody-log:urb (cue xtr))
+::
+::  +walk-checks: the PURE custody walk.  Given the comet's name, its current
+::  messaging key, the spawn satpoint (from dat), the custody log (from xtr) and
+::  the fetched tx for each entry (aligned by index; ~ = fetch failed), verify
+::  every link and fold to the latest committed state.  ~ on any failure.
+::
+++  walk-checks
+  |=  $:  who=ship
+          cry=@
+          spawn-sont=sont:ord
+          log=custody-log:urb
+          fetched=(list (unit tx:bc))
+      ==
+  ^-  (unit [tip=sont:ord state=gw-state:urb])
+  ?~  log  ~
+  ?~  fetched  ~
+  ?.  =((lent log) (lent fetched))  ~
+  ::  entry-0: the spawn commit.  Its tx must be the spawn tx (dat's txid), it
+  ::  must carry a %spawn reveal, and that reveal must commit to the sat's home
+  ::  output (spawn-sont).  Initial state comes from the %spawn.
+  ?~  tx0=i.fetched  ~
+  ?~  rev0=reveal.i.log  ~
+  ?.  =(id.u.tx0 txid.spawn-sont)  ~
+  ?~  onchain0=(p2tr-at u.tx0 vout.spawn-sont)  ~
+  ?.  =(u.onchain0 (out-key u.rev0))  ~
+  ?~  state0=(parse-spawn-state who u.rev0)  ~
+  =/  state=gw-state:urb  u.state0
+  =/  sont=sont:ord  spawn-sont
+  =/  entries  t.log
+  =/  txs      t.fetched
+  |-
+  ^-  (unit [tip=sont:ord state=gw-state:urb])
+  ?~  entries  `[sont state]
+  ?~  txs  ~
+  ?~  this=i.txs  ~
+  =/  entry  i.entries
+  ::  the fetched tx must be the one the entry names
+  ?.  =(id.u.this txid.entry)  ~
+  ::  continuity: input 0 key-path-spends the exact prior sat-carrying output
+  ?~  inp=(snag-input 0 u.this)  ~
+  ?.  =([txid.u.inp pos.u.inp] [txid.sont vout.sont])  ~
+  ?.  (is-key-path witness.u.inp)  ~
+  ::  track the sat to its landing output (input 0 => no input value precedes
+  ::  it, so it enters at index = its offset).  ~ = fell into the miner fee.
+  =/  landed  (index-to-sont:uc off.sont os.u.this)
+  ?~  landed  ~
+  =/  next=sont:ord  [id.u.this vout.landed off.landed]
+  ::  a state-bearing entry: the landing output must commit the revealed leaf,
+  ::  and its %state becomes the new authoritative state.  A bare entry
+  ::  (reveal=~) is a pure custody move and leaves the state unchanged.
+  =/  new-state=(unit gw-state:urb)
+    ?~  reveal.entry  `state
+    ?~  onchain=(p2tr-at u.this vout.landed)  ~
+    ?.  =(u.onchain (out-key u.reveal.entry))  ~
+    ?~  ps=(parse-state u.reveal.entry)  ~
+    `-.u.ps
+  ?~  new-state  ~
+  $(entries t.entries, txs t.txs, sont next, state u.new-state)
+::
+::  +to-jael-point: project the latest committed state onto Jael's $point,
+::  storing the (verified) full incoming pass as the current life's key.
+::  Per spec section 7 the confidential verdict is rift 0, fief ~.
+::
+++  to-jael-point
+  |=  [=pass state=gw-state:urb]
+  ^-  point:jael
+  :*  rift=0
+      life.state
+      (my [life.state (sub (end 3 pass) 'a') pass] ~)
+      sponsor.state
+      ~
+  ==
+::
+::  +verify: the async entrypoint.  Decode + validate the pass, fetch the
+::  custody log's txs (each in its attested block, so no -txindex needed),
+::  run +walk-checks, confirm the tip is unspent and the pass's key is current,
+::  and produce the verdict point (or ~).
+::
+++  verify
+  |=  [dom=@tas who=ship =pass rpc=req-to:btcio]
+  =/  m  (strand:strandio ,(unit point:jael))
+  ^-  form:m
+  =/  cek  +<:(com:nu:cric:crypto pass)
+  ?.  ?=([%c *] cek)  (pure:m ~)
+  =/  cry  cry.pub.cek
+  ::  domain committed in the tweak must match what Jael routed
+  ?.  =(dom `@tas`q:(rub 0 dat.tw.pub.cek))  (pure:m ~)
+  ::  name must be the fingerprint of the tweaked key (re-derive, don't trust)
+  ?.  =(who fig:ex:(com:nu:cric:crypto pass))  (pure:m ~)
+  ?~  spawn-sont=(parse-dat-sont dat.tw.pub.cek)  (pure:m ~)
+  ?~  log=(parse-custody-log xtr.tw.pub.cek)  (pure:m ~)
+  ::  fetch each entry's tx in its attested block (height -> hash -> in-block)
+  ;<  fetched=(list (unit tx:bc))  bind:m  (fetch-log rpc u.log)
+  =/  walk  (walk-checks who cry u.spawn-sont u.log fetched)
+  ?~  walk  (pure:m ~)
+  ::  the tip output must be unspent on our node
+  ;<  live=(unit ?)  bind:m
+    (get-tx-out:btcio rpc ~ txid.tip.u.walk vout.tip.u.walk)
+  ?.  =(`%.y live)  (pure:m ~)
+  ::  the pass's current messaging key must be the latest attested one
+  ?.  =(cry key.state.u.walk)  (pure:m ~)
+  (pure:m `(to-jael-point pass state.u.walk))
+::
+::  +fetch-log: resolve each entry's block-height to a hash and fetch the tx in
+::  that block.  Preserves order + arity so +walk-checks can zip by index; a
+::  failed fetch stays ~ and fails the walk at that link.
+::
+++  fetch-log
+  |=  [rpc=req-to:btcio log=custody-log:urb]
+  =/  m  (strand:strandio ,(list (unit tx:bc)))
+  ^-  form:m
+  =|  acc=(list (unit tx:bc))
+  |-
+  ^-  form:m
+  ?~  log  (pure:m (flop acc))
+  ;<  bh=(unit @ux)  bind:m  (get-block-hash:btcio rpc ~ block-height.i.log)
+  ?~  bh  $(log t.log, acc [~ acc])
+  ;<  tx=(unit tx:bc)  bind:m
+    (get-raw-transaction-in-block:btcio rpc ~ txid.i.log u.bh)
+  $(log t.log, acc [tx acc])
+--

--- a/groundwire/lib/taproot.hoon
+++ b/groundwire/lib/taproot.hoon
@@ -1,0 +1,247 @@
+::  taproot.hoon - Taproot script tree utilities
+::
+::  Ported into the groundwire desk from spv-wallet/lib/taproot.hoon, trimmed to
+::  the arms the self-attestation verifier (lib/self-attestation, used by
+::  %urb-watcher) needs to VERIFY a confidential comet's commitments:
+::  TapLeaf/TapBranch hashing, BIP-341 key tweaking, and the output-key
+::  reconstruction used to check that an off-chain-revealed tapleaf was committed
+::  in an on-chain taproot output. The bech32/address helpers were dropped.
+::
+::  Provides operations on partial tapscript trees (ptst):
+::  - Hash computation (TapLeaf, TapBranch)
+::  - Leaf enumeration with axis addressing
+::  - Merkle proof extraction / reconstruction
+::  - Output-key tweaking (Q = P + t*G)
+::
+/+  bcu=bitcoin-utils, btc=bitcoin
+::
+::  secp256k1 curve order (n)
+::
+|%
+++  secp-n  0xffff.ffff.ffff.ffff.ffff.ffff.ffff.fffe.baae.dce6.af48.a03b.bfd2.5e8c.d036.4141
+::  Taproot script tree types
+::
++$  tapleaf  [version=@ux script=hexb:btc]
++$  ptst  ::  partial tapscript tree
+  $@  ~
+  $%  [%leaf =tapleaf]
+      [%opaque hash=@ux]
+      [%branch l=ptst r=ptst]
+  ==
+::
+::  +leaf-hash: compute TapLeaf hash for a tapleaf
+::
+++  leaf-hash
+  |=  =tapleaf
+  ^-  @ux
+  =/  script-len=@  wid.script.tapleaf
+  =/  compact-size=hexb:btc
+    ?:  (lth script-len 0xfd)  [1 `@ux`script-len]
+    ?:  (lth script-len 0x1.0000)
+      (cat:byt:bcu ~[[1 0xfd] (flip:byt:bcu [2 script-len])])
+    ?:  (lth script-len 0x1.0000.0000)
+      (cat:byt:bcu ~[[1 0xfe] (flip:byt:bcu [4 script-len])])
+    (cat:byt:bcu ~[[1 0xff] (flip:byt:bcu [8 script-len])])
+  =/  leaf-data=hexb:btc
+    %-  cat:byt:bcu
+    :~  [1 version.tapleaf]
+        compact-size
+        script.tapleaf
+    ==
+  (tagged-hash 'TapLeaf' leaf-data)
+::
+::  +hash: get the hash of a ptst node
+::
+++  hash
+  |=  tree=ptst
+  ^-  @ux
+  ?~  tree  0x0
+  ?-  -.tree
+    %leaf    (leaf-hash tapleaf.tree)
+    %opaque  hash.tree
+      %branch
+    =/  left-hash=@ux   (hash l.tree)
+    =/  right-hash=@ux  (hash r.tree)
+    ::  TapBranch: sort hashes lexicographically
+    =/  [first=@ux second=@ux]
+      ?:  (lth left-hash right-hash)
+        [left-hash right-hash]
+      [right-hash left-hash]
+    =/  branch-data=hexb:btc
+      (cat:byt:bcu ~[[32 first] [32 second]])
+    (tagged-hash 'TapBranch' branch-data)
+  ==
+::  +leaves: get all leaves with their axis addresses
+::
+::  Uses Nock axis addressing: 1=root, 2=left, 3=right, etc.
+::
+++  leaves
+  |=  tree=ptst
+  ^-  (list [axis=@ =tapleaf])
+  (leaves-at tree 1)
+::
+++  leaves-at
+  |=  [tree=ptst axis=@]
+  ^-  (list [axis=@ =tapleaf])
+  ?~  tree  ~
+  ?-  -.tree
+    %leaf    [[axis tapleaf.tree] ~]
+    %opaque  ~
+      %branch
+    %+  weld
+      (leaves-at l.tree (mul 2 axis))
+    (leaves-at r.tree +((mul 2 axis)))
+  ==
+::  +proof: get merkle proof for leaf at given axis
+::
+::  Returns ~ if no leaf at that axis.
+::  Returns list of sibling hashes from leaf to root.
+::
+++  proof
+  |=  [tree=ptst axis=@]
+  ^-  (unit (list @ux))
+  ?~  tree  ~
+  ?:  =(1 axis)
+    ::  At root - must be a leaf
+    ?.  ?=(%leaf -.tree)  ~
+    `~
+  ::  Navigate to target, collecting sibling hashes
+  =/  path=(list ?)  (axis-to-path axis)
+  (proof-walk tree path ~)
+::
+++  proof-walk
+  |=  [tree=ptst path=(list ?) siblings=(list @ux)]
+  ^-  (unit (list @ux))
+  ?~  tree  ~
+  ?~  path
+    ::  Reached target - must be a leaf
+    ?.  ?=(%leaf -.tree)  ~
+    `siblings
+  ?.  ?=(%branch -.tree)  ~
+  =/  go-left=?  i.path
+  =/  sibling-hash=@ux
+    ?:  go-left
+      (hash r.tree)
+    (hash l.tree)
+  =/  next-tree=ptst  ?:(go-left l.tree r.tree)
+  $(tree next-tree, path t.path, siblings (snoc siblings sibling-hash))
+::  +axis-to-path: convert axis to list of left/right decisions
+::
+::  Returns path from root to target (%.y = left, %.n = right)
+::
+++  axis-to-path
+  |=  axis=@
+  ^-  (list ?)
+  ?:  =(1 axis)  ~
+  =/  parent=@  (div axis 2)
+  =/  is-left=?  =(0 (mod axis 2))
+  (snoc (axis-to-path parent) is-left)
+::  +tagged-hash: BIP-340 tagged hash
+::
+::  tagged_hash(tag, data) = SHA256(SHA256(tag) || SHA256(tag) || data)
+::  Defers to the standard library's implementation (same as groundwire)
+::
+++  tagged-hash
+  |=  [tag=@t data=hexb:btc]
+  ^-  @ux
+  `@ux`(tagged-hash:schnorr:secp256k1:secp:crypto tag [p=wid.data q=dat.data])
+::  +has-leaf: check if tree contains at least one leaf
+::
+++  has-leaf
+  |=  tree=ptst
+  ^-  ?
+  ?~  tree  %.n
+  ?-  -.tree
+    %leaf    %.y
+    %opaque  %.n
+    %branch  ?|((has-leaf l.tree) (has-leaf r.tree))
+  ==
+::
+::  Constructors
+::
+++  make-leaf    |=(=tapleaf ^-(ptst [%leaf tapleaf]))
+++  make-branch  |=([l=ptst r=ptst] ^-(ptst [%branch l r]))
+++  make-opaque  |=(h=@ux ^-(ptst [%opaque h]))
+::
+::  ============================================================================
+::  Key Tweaking (BIP-341)
+::  ============================================================================
+::
+::  +x-only: extract x-coordinate from compressed pubkey
+::
+::  Takes 33-byte compressed pubkey, returns 32-byte x-only pubkey.
+::
+++  x-only
+  |=  pubkey=@ux
+  ^-  @ux
+  (end [3 32] pubkey)
+::
+::  +compute-tweak: compute taproot tweak value
+::
+::  tweak = tagged_hash("TapTweak", internal_pubkey_x || merkle_root)
+::  If merkle_root is ~, tweak = tagged_hash("TapTweak", internal_pubkey_x)
+::
+++  compute-tweak
+  |=  [internal-pubkey-x=@ux merkle-root=(unit @ux)]
+  ^-  @ux
+  =/  data=hexb:btc
+    ?~  merkle-root
+      [32 internal-pubkey-x]
+    (cat:byt:bcu ~[[32 internal-pubkey-x] [32 u.merkle-root]])
+  (tagged-hash 'TapTweak' data)
+::
+::  +tweak-pubkey: compute tweaked output pubkey
+::
+::  Takes internal pubkey (33-byte compressed) and optional merkle root.
+::  Returns [tweaked-x-only-pubkey parity].  Q = P + t*G.
+::
+++  tweak-pubkey
+  |=  [internal-pubkey=@ux merkle-root=(unit @ux)]
+  ^-  [x=@ux parity=?]
+  =,  secp256k1:secp:crypto
+  ::  Get internal pubkey as a point
+  =/  p=point  (decompress-point internal-pubkey)
+  ::  If P has odd y, negate it (lift to even y) for consistent tweaking
+  =/  p-even=point
+    ?:  =(0 (mod y.p 2))
+      p
+    [x.p (sub p:domain:curve y.p)]
+  ::  Compute tweak
+  =/  tweak=@ux  (compute-tweak (x-only internal-pubkey) merkle-root)
+  ::  Q = P + t*G
+  =/  t-times-g=point  (mul-point-scalar g:domain:curve tweak)
+  =/  q=point  (add-points p-even t-times-g)
+  :-  x.q
+  !=(0 (mod y.q 2))
+::
+::  +output-pubkey: compute taproot output key (for scriptPubKey)
+::
+::  Convenience: returns just the x-only output pubkey.
+::
+++  output-pubkey
+  |=  [internal-pubkey=@ux merkle-root=(unit @ux)]
+  ^-  @ux
+  x:(tweak-pubkey internal-pubkey merkle-root)
+::
+::  +merkle-root-from-proof: compute merkle root from leaf and proof
+::
+::  Given a tapleaf and its merkle proof (list of sibling hashes),
+::  reconstructs the merkle root by walking up the tree.  An empty proof
+::  yields the leaf hash itself (a single-leaf tree).
+::
+++  merkle-root-from-proof
+  |=  [=tapleaf proof=(list @ux)]
+  ^-  @ux
+  =/  current=@ux  (leaf-hash tapleaf)
+  |-
+  ?~  proof
+    current
+  =/  sibling=@ux  i.proof
+  =/  [first=@ux second=@ux]
+    ?:  (lth current sibling)
+      [current sibling]
+    [sibling current]
+  =/  branch-data=hexb:btc
+    (cat:byt:bcu ~[[32 first] [32 second]])
+  $(current (tagged-hash 'TapBranch' branch-data), proof t.proof)
+--

--- a/groundwire/lib/urb-core.hoon
+++ b/groundwire/lib/urb-core.hoon
@@ -591,9 +591,16 @@
             sots     t.sots
             unv-ids   (~(put by unv-ids) who u.point)
         ==
+      ::
+      ::  %state (opcode 9) is a CONFIDENTIAL off-chain networking-state
+      ::  re-attestation; the on-chain block indexer never enacts it -- it
+      ::  is meaningful only inside a comet's xtr reveal log, verified by
+      ::  lib/gw-verify.  If one ever appears in an on-chain reveal, skip it.
+          %state
+        $(sots t.sots)
       ==
       ::
-      ::  Is this sont in the input that's being processed? 
+      ::  Is this sont in the input that's being processed?
       ++  is-sont-in-input
         |=  sot=sont:ord
         ~|  [s=sot [txid pos value]:i.inputs]

--- a/groundwire/lib/urb-encoder.hoon
+++ b/groundwire/lib/urb-encoder.hoon
@@ -141,6 +141,21 @@
         %reject         6
         %detach         7
       ==
+    ::
+    ::  %state (opcode 9): a confidential-comets networking-state snapshot
+    ::  (life, messaging key, sponsor+consent).  See sur/urb and
+    ::  lib/gw-verify.  Encoding pinned by pier round-trip; the sponsor is
+    ::  a bloq-0 subslice tagged like en-sig (2-bit unit tag, then 128-bit
+    ::  ship + 512-bit consent sig).
+        %state
+      |^  ^+  ^$
+      [[7 9] (mat life.sot) (mat key.sot) en-sponsor ~]
+      ++  en-sponsor
+        ^-  plat:plot
+        :+  s+~  0
+        ?~  sponsor.sot  ~[[2 0]]
+        ~[[2 1] [128 who.u.sponsor.sot] [512 sig.u.sponsor.sot]]
+      --
     ==
   ++  en-sig
     |=  sig=(unit @)
@@ -299,7 +314,15 @@
         %6   =^(res cur take-ship `[[%reject res] cur])
         %7   =^(res cur take-ship `[[%detach res] cur])
         %8   =^(res cur take-mang ?~(res ~ `[[%set-mang u.res] cur]))
-        ::%9   =^(res cur take-sont `[[%set-spawn-proxy res] cur])
+    ::
+    ::  %9: confidential-comets networking-state snapshot (see the %state
+    ::  encoder above and lib/gw-verify).  life, key, then a sponsor unit
+    ::  tagged exactly like take-sig.
+        %9
+      =^  life=@ud                cur  take-atom
+      =^  key=@                    cur  take-atom
+      =^  spo=(unit consent:urb)  cur  take-sponsor
+      `[[%state life key spo] cur]
         %10
       =^  len  cur  take-atom
       =|  bat=(list single:skim-sotx:urb)
@@ -387,5 +410,15 @@
     ?.  =(typ 1)  ~&  >>  %take-sig  !!
     =^  sig  cur  (take 0 512)
     `[`sig cur]
+  ::  decode a %state sponsor: a 2-bit unit tag, then (if present) a
+  ::  128-bit sponsor ship and a 512-bit consent signature.
+  ++  take-sponsor
+    ^-  [(unit consent:urb) @ud]
+    =^  typ  cur  (take 0 2)
+    ?:  =(typ 0)  [~ cur]
+    ?.  =(typ 1)  ~&  >>>  %take-sponsor  !!
+    =^  who=@p  cur  (take 0 128)
+    =^  sig=@   cur  (take 0 512)
+    [`[who sig] cur]
   --
 --

--- a/groundwire/sur/urb.hoon
+++ b/groundwire/sur/urb.hoon
@@ -12,11 +12,45 @@
 ::  the confidential-comets protocol.  %jael-writ asks us to verify a
 ::  comet's self-attestation ($pass); %jael-anew asks us to re-encode
 ::  our own comet's pass with a fresh off-chain reveal log.  see
-::  app/groundwire.hoon and, in gwbtc/urbit, sys/vane/jael.hoon.
+::  app/gw-btc.hoon and, in gwbtc/urbit, sys/vane/jael.hoon.
 ::
 +$  jael-poke
   $%  [%jael-writ dom=@tas who=ship =pass]
       [%jael-anew dom=@tas]
+  ==
+::  Confidential-comets custody log (spec section 8, variant B).  The
+::  off-chain reveal of an on-chain, key-path-spend ownership history for
+::  a single sat: one $xtr-entry per spend, spawn -> tip.  It rides in the
+::  (untweaked) .xtr of a suite-%c pass and is verified by lib/gw-verify
+::  against the agent's own bitcoin node.  The log is a LOCATOR, not a
+::  proof: each entry names a txid + block-height the agent fetches and
+::  re-checks; state commitments (spec section 2.1) mean only entries that
+::  carry a $reveal re-attest networking state, and only the latest such
+::  one is authoritative -- bare entries (reveal=~) just prove the sat
+::  moved (an ordinary transfer from any wallet).
+::
+::  $reveal: the disclosed tapleaf and its internal key, enough to
+::  recompute the committed output key Q = P + H_TapTweak(x(P)||leaf-hash)*G
+::  (single-leaf sparse tree, so the merkle root IS the leaf hash) and to
+::  re-parse the committed $sotx(es) from the leaf script.
+::
++$  reveal
+  $:  internal-key=@ux              ::  P (x-only, 32 bytes)
+      leaf-version=@ux              ::  tapleaf version byte (0xc0)
+      leaf-script=hexb:bitcoin      ::  the committed script (an "unv")
+  ==
++$  xtr-entry  [txid=@ux block-height=@ud reveal=(unit reveal)]
++$  custody-log  (list xtr-entry)
+::
+::  $gw-state: the networking state a %spawn or %state commitment attests
+::  (spec section 2.1: keys, life, sponsorship).  Distinct from $point:
+::  this is the intermediate the custody walk folds toward the latest
+::  commitment before projecting onto Jael's $point.
+::
++$  gw-state
+  $:  =life
+      key=@                             ::  messaging key (cry.pub of the pass)
+      sponsor=(unit @p)
   ==
 +$  state
   $:  block-id=id:block:bitcoin
@@ -43,7 +77,7 @@
     $%  $:  %spawn  =pass
             ::from=(unit [=vout =off])
             fief=(unit fief)
-            to=[spkh=@ux vout=(unit vout:ord) =off:ord tej=off:ord] 
+            to=[spkh=@ux vout=(unit vout:ord) =off:ord tej=off:ord]
         ==
         [%keys =pass breach=?]
         [%escape parent=ship sig=(unit @)]
@@ -53,8 +87,27 @@
         [%detach =ship]
         [%fief fief=(unit fief)]
         [%set-mang mang=(unit mang)]
+        ::  %state (opcode 9): a full networking-STATE re-attestation for
+        ::  the confidential-comets protocol (state-commitments model, spec
+        ::  section 2.1).  Unlike the event singles above, %state is a
+        ::  snapshot: the identity's current life, messaging key, and
+        ::  sponsor.  Committed in an off-chain-revealed tapleaf; the
+        ::  latest such commitment along a sat's custody chain is the
+        ::  authoritative state (see lib/gw-verify).  A sponsor carries a
+        ::  Schnorr consent signature proving it agreed to adopt the child.
+        ::
+        ::  .key is the raw messaging key (cry.pub of the suite-%c pass),
+        ::  NOT a full $pass: the signing key that fixes the @p is immutable
+        ::  (spec section 2.1), so only the encryption key rotates and needs
+        ::  re-attesting.
+        [%state =life key=@ sponsor=(unit consent)]
     ==
   --
+::
+::  $consent: a sponsor's assent to sponsor a confidential comet, as
+::  committed in a %state leaf.  .who is the sponsor @p; .sig is its
+::  BIP-340 Schnorr signature over the consent message (see lib/gw-verify).
++$  consent  [who=@p sig=@]
 ::
 +$  mang  $%([%sont =sont:ord] [%pass =pass])
 ::

--- a/groundwire/sur/urb.hoon
+++ b/groundwire/sur/urb.hoon
@@ -35,7 +35,9 @@
 ::  re-parse the committed $sotx(es) from the leaf script.
 ::
 +$  reveal
-  $:  internal-key=@ux              ::  P (x-only, 32 bytes)
+  $:  internal-key=@ux              ::  P, 33-byte COMPRESSED (0x02/0x03 ||
+      ::                                x), as lib/taproot's decompress-point
+      ::                                and Causeway's xtr encoder require
       leaf-version=@ux              ::  tapleaf version byte (0xc0)
       leaf-script=hexb:bitcoin      ::  the committed script (an "unv")
   ==

--- a/groundwire/tests/app/gw-btc.hoon
+++ b/groundwire/tests/app/gw-btc.hoon
@@ -1,12 +1,12 @@
-/-  spider, bitcoin, urb, ord, uw=urb-watcher
+/-  spider, bitcoin, urb, ord, uw=urb
 /+  tag=test-agent, btcio, btcl=bitcoin, ol=ord
-/=  mock-agent  /app/urb-watcher
+/=  mock-agent  /app/gw-btc
 =>
 ::
 ::  def
 |%
-++  dap   %mock-urb-watcher
-++  dek   %groundwire
+++  dap   %mock-gw-btc
+++  dek   %gw-btc
 ++  doc   [~zod dap]
 ::
 ++  mock-req-to


### PR DESCRIPTION
## What

Renames the confidential-comets verifier agent **`%groundwire` → `%gw-btc`** and replaces its stubbed variant-B custody walk with a real implementation of the kernel spec's §7 verification (gwbtc/urbit `cyc/cc-draft-2`, `pkg/arvo/doc/spec/confidential-comets.md`).

Builds directly on `b88c7dc` (the indexed-path agent) — this PR fills the `XX`-stubbed confidential path and does the domain rename.

## Why `%gw-btc`

The domain tag is `+mat`-encoded into `dat.tw.pub`, which is hashed into every comet's signing key and therefore its `@p`, **forever**. The tag must name the **PKI domain** (the Groundwire Bitcoin PKI), not the agent implementation. `%groundwire` was the implementation codename; `%gw-btc` names the domain. Jael derives the same tag 1:1 from the gall duct our `%anex` arrives on, so agent-name *is* domain-name — renaming later would orphan every comet minted against the old tag. Do it now, before comets exist.

## The two verify paths (`app/gw-btc.hoon`)

- **Indexed (fast, synchronous)** — a comet whose on-chain reveal our block-watcher already parsed into `unv-ids`. `+verify-indexed` checks suite/domain/`fig`, then compares the **messaging key `cry`** (not the whole pass — the pass's `xtr` reveal-log grows independently, so a whole-pass compare spuriously rejects a longer log; the `@p` is already pinned by the `fig` check). *This fixes the prior `=(pass pass.net.u.pt)` comparison.*
- **Confidential (async)** — an unindexed comet: a khan thread runs `lib/gw-verify`'s §7 custody walk against our bitcoin node; the `%writ-response` fact is emitted from `+on-arvo` when it returns.

## New / changed

| file | change |
|---|---|
| `lib/gw-verify.hoon` | **new** — §7 custody walk: decode suite-%c pass (`cry`/`dat`/`xtr`), walk the custody log spawn→tip (key-path continuity + single-leaf taproot commitments), interpret only the latest `%state` (state-commitments), project onto `point:jael`. Pure `+walk-checks` is node-free. |
| `lib/taproot.hoon` | **new** — ported from spv-wallet; TapLeaf/TapTweak + output-key reconstruction. |
| `lib/urb-encoder.hoon` `sur/urb.hoon` | `%state` single (opcode 9): `[life key sponsor(+consent)]` snapshot; `$reveal`/`$xtr-entry`/`$custody-log`/`$gw-state`. |
| `lib/btcio.hoon` | `get-raw-transaction-in-block` + `get-tx-out`. |
| `app/gw-btc.hoon` (rename) `desk.bill` `app/urb-snapshot` `reg-tester` `tests/app` `doc/` | rename + wiring. |

## Verification

The environment can't compile the agent (needs the cc-draft-2 `%base` for `point:jael`), so the **pure consensus primitives were pinned by `urbit eval`**:

- **taproot tweak** `Q = P + H_TapTweak(x(P)‖root)·G` matches the **BIP-341 test vector** (`0x53a1f6e4…a343`).
- **`%state` codec** encode/decode round-trips.
- **`dat` decode** (`+parse-dat-sont`) recovers Causeway's `dat` golden vector exactly (dom + txid + vout + off) — a cross-impl check (Causeway TS ↔ this Hoon).
- The verifier logic itself is written against §7 and adversarially reviewed, but **needs a fakeship/aqua run** to test end-to-end.

## Companion Causeway change

`hd/causeway-confidential` (PR #124) is updated to emit the matching `xtr` `$custody-log`: `[txid block-height reveal=(unit reveal)]` (block-**height** not hash; `reveal` optional for pure custody hops). Golden vectors regenerated against `(jam)` and pinned across Hoon/TS/Python (web 100, desktop 47 tests green).

## Flagged for spec-author (cyc) review — consensus-critical

1. **Sponsor-consent signature** — an addition over §7 (which records the sponsor ship but no consent proof). The `%state` leaf carries a sponsor Schnorr sig; the *verification* of that sig is a TODO (marked in `gw-verify`).
2. **txid byte order** in `dat`/`xtr` vs the node's tx ids (`XX` in `+parse-dat-sont`) — must be the same convention Causeway emits.
3. **entry-0 (spawn) placement** and `%spawn`→initial-state extraction — a reasonable reading of the §7 pseudocode, not a pinned spec.
4. **`%state` leaf emission for re-attestations** — spawn verification works end-to-end today; Causeway still emits legacy `%keys`/`%escape` event leaves for rekey/escape, which should become `%state` snapshots (follow-up, noted in the Causeway commit).
5. The prior **stale agent test** (`tests/app`) is repointed but still needs a proper rewrite for the confidential path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
